### PR TITLE
ensure libpython2.7 is installed.

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
            libcurl4-openssl-dev \
            imagemagick \
            python-pip \
+           libpython2.7 \
     && pip install --upgrade pip \
     && pip install virtualenv \
     && echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' >> /etc/R/Rprofile.site \


### PR DESCRIPTION
I have a machine with a fresh install of Ubuntu 16.04, Docker 17.12.0-ce, and NVIDIA-docker v2. `libpython2.7` was missing as demonstrated by the following code.

```
> reticulate::py_available(TRUE)
[1] FALSE
```
after making the modification in this PR and rebuilding, the previous code returns `TRUE`.

this addresses https://github.com/rocker-org/rocker/issues/273#issuecomment-355368728