### PR TITLE
Build xgboost for R with multi-GPU support

### DIFF
--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget cmake && \
     git clone --recursive https://github.com/dmlc/xgboost && \
     mkdir -p xgboost/build && cd xgboost/build && \
-    cmake .. -DUSE_CUDA=ON -DR_LIB=ON && \
+    cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
     make install -j$(nproc)
 
 FROM rocker/tensorflow-gpu:3.5.2

--- a/ml/gpu/tests.R
+++ b/ml/gpu/tests.R
@@ -9,6 +9,11 @@ test <- agaricus.test
 # fit model
 bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 100,
                nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist")
+
+# Test for multi-gpu support
+#bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 10000,
+#               nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist", n_gpus=4)
+
 # predict
 pred <- predict(bst, test$data)
 


### PR DESCRIPTION
One little tweak required to let the xgboost R package run on multiple GPUs. Adding a commented-out multi-GPU that runs with this change.

Everything in the test script runs fine on my hardware (2X GTX 1080, 2X Titan XP) .  

I also attempted to fit a multi-GPU Keras model (https://keras.rstudio.com/reference/multi_gpu_model.html).  This had issues because of an apparent bug in 1.12 compatibility (https://github.com/rstudio/tensorflow/issues/272).  Reverting to 1.10 detected all my GPUs but there was some memory issue.  The R package didn't detect tensorflow when I trieed installing 1.13rc2 .

