### PR TITLE
Opencl requirements

### DIFF
--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -62,3 +62,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 
+####### Set up env variables in R #######
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV PATH=$CUDA_HOME/bin:$PATH
+ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+
+RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserver.conf \
+  && echo "\n\
+         \nCUDA_HOME=$CUDA_HOME \
+         \nCUDA_PATH=$CUDA_PATH \
+         \nPATH=$PATH" >> /usr/local/lib/R/etc/Renviron
+         

--- a/cuda/devel/Dockerfile
+++ b/cuda/devel/Dockerfile
@@ -27,3 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-mark hold libcudnn7 && \
     rm -rf /var/lib/apt/lists/*
 
+### required for linking OpenCL
+RUN mkdir -p /etc/OpenCL/vendors/ \
+  && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd

--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget cmake && \
     git clone --recursive https://github.com/dmlc/xgboost && \
     mkdir -p xgboost/build && cd xgboost/build && \
-    cmake .. -DUSE_CUDA=ON -DR_LIB=ON && \
+    cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
     make install -j$(nproc)
 
 FROM rocker/tensorflow-gpu:3.5.2

--- a/ml/gpu/tests.R
+++ b/ml/gpu/tests.R
@@ -9,6 +9,11 @@ test <- agaricus.test
 # fit model
 bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 100,
                nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist")
+
+# Test for multi-gpu support
+#bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 10000,
+#               nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist", n_gpus=4)
+
 # predict
 pred <- predict(bst, test$data)
 

--- a/tensorflow/gpu/Dockerfile
+++ b/tensorflow/gpu/Dockerfile
@@ -1,18 +1,6 @@
 FROM rocker/cuda:3.5.2
 
-# Set up env variables in R
-ENV CUDA_HOME=/usr/local/cuda
-ENV CUDA_PATH=/usr/local/cuda
-ENV PATH=$CUDA_HOME/bin:$PATH
-ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-
-RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserver.conf \
-  && echo "\n\
-         \nTENSORFLOW_PYTHON=/usr/bin/python3 \
-         \nCUDA_HOME=$CUDA_HOME \
-         \nCUDA_PATH=$CUDA_PATH \
-         \nPATH=$PATH" >> /usr/local/lib/R/etc/Renviron
-
+RUN echo "\nTENSORFLOW_PYTHON=/usr/bin/python3 >> /usr/local/lib/R/etc/Renviron
 
 ## Python
 RUN apt-get update -qq \


### PR DESCRIPTION
CUDA environment path variables are used by several packages, so it makes sense to install them in the base cuda image rather than the Tensorflow one.

I found I could install gpuR on top of `cuda-dev`, but not `cuda`.  OpenCl is part of the NVIDIA cuda developer libraries so it didn't require an additional install.  It did require the tweak at the bottom of the cuda-dev Dockerfile, which I found here: https://github.com/cdeterman/gpuR/issues/52.

This includes my other PR.