### PR TITLE
Add a GPU image with mxnet and xgboost

### DIFF
--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -62,3 +62,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 
+####### Set up env variables in R #######
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV PATH=$CUDA_HOME/bin:$PATH
+ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+
+RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserver.conf \
+  && echo "\n\
+         \nCUDA_HOME=$CUDA_HOME \
+         \nCUDA_PATH=$CUDA_PATH \
+         \nPATH=$PATH" >> /usr/local/lib/R/etc/Renviron
+         

--- a/cuda/devel/Dockerfile
+++ b/cuda/devel/Dockerfile
@@ -27,3 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-mark hold libcudnn7 && \
     rm -rf /var/lib/apt/lists/*
 
+### required for linking OpenCL
+RUN mkdir -p /etc/OpenCL/vendors/ \
+  && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd

--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -2,7 +2,7 @@ FROM rocker/cuda-dev:3.5.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget cmake && \
-    git clone --recursive https://github.com/dmlc/xgboost && \
+    git clone --recursive --branch v0.81 https://github.com/dmlc/xgboost && \
     mkdir -p xgboost/build && cd xgboost/build && \
     cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
     make install -j$(nproc)

--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget cmake && \
     git clone --recursive https://github.com/dmlc/xgboost && \
     mkdir -p xgboost/build && cd xgboost/build && \
-    cmake .. -DUSE_CUDA=ON -DR_LIB=ON && \
+    cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
     make install -j$(nproc)
 
 FROM rocker/tensorflow-gpu:3.5.2

--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -13,7 +13,8 @@ FROM rocker/tensorflow-gpu:3.5.2
 RUN pip3 install \
     wheel==0.33.0 \
     setuptools==40.8.0 \
-    scipy==1.2.1 --upgrade
+    scipy==1.2.1 \
+    tensorflow-probability==0.5.0 --upgrade
 
 ## xgboost with multi-GPU support
 RUN apt-get update && apt-get -y install wget && \

--- a/ml/gpu/tests.R
+++ b/ml/gpu/tests.R
@@ -9,6 +9,11 @@ test <- agaricus.test
 # fit model
 bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 100,
                nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist")
+
+# Test for multi-gpu support
+#bst <- xgboost(data = train$data, label = train$label, max_depth = 5, eta = 0.001, nrounds = 10000,
+#               nthread = 2, objective = "binary:logistic", tree_method = "gpu_hist", n_gpus=4)
+
 # predict
 pred <- predict(bst, test$data)
 

--- a/mxnet/cpu/Dockerfile
+++ b/mxnet/cpu/Dockerfile
@@ -1,0 +1,28 @@
+FROM rocker/tidyverse:3.5.2
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    build-essential \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+    
+RUN git clone --recursive --branch 1.3.1 https://github.com/apache/incubator-mxnet.git \
+  &&  cd incubator-mxnet \
+  &&  make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
+
+RUN cd incubator-mxnet \
+  && make rpkg
+  
+FROM rocker/tidyverse:3.5.2
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+    
+COPY --from=0 /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+
+RUN install2.r \
+  xgboost

--- a/mxnet/cpu/hooks/post_push
+++ b/mxnet/cpu/hooks/post_push
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "Working dir and contents I see are:"
+echo `pwd`
+echo `ls`
+
+## Not all bash commands are available. notably grep -o -e options fail!!
+VERSION=`cat Dockerfile | head -n1 | sed 's/.*\([0-9].[0-9].[0-9]\).*/\1/'`
+echo "Version being built is:"
+echo $VERSION
+
+echo "tagging $IMAGE_NAME as $DOCKER_REPO:$VERSION..."
+docker tag $IMAGE_NAME $DOCKER_REPO:$VERSION
+
+echo "pushing $DOCKER_REPO:$VERSION to hub..."
+docker push $DOCKER_REPO:$VERSION
+
+
+# docker tag $IMAGE_NAME $DOCKER_REPO:$SOURCE_BRANCH
+# docker push $DOCKER_REPO:$SOURCE_BRANCH
+
+

--- a/mxnet/gpu/Dockerfile
+++ b/mxnet/gpu/Dockerfile
@@ -2,7 +2,7 @@ FROM rocker/cuda-dev:3.5.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget cmake && \
-    git clone --recursive https://github.com/dmlc/xgboost && \
+    git clone --recursive --branch v0.81 https://github.com/dmlc/xgboost && \
     mkdir -p xgboost/build && cd xgboost/build && \
     cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
     make install -j$(nproc)
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
     libopencv-dev \
     libxt-dev
     
-RUN git clone --recursive https://github.com/apache/incubator-mxnet.git \
+RUN git clone --recursive --branch 1.3.1 https://github.com/apache/incubator-mxnet.git \
   &&  cd incubator-mxnet \
   &&  echo "USE_OPENCV = 1" >> ./config.mk \
   &&  echo "USE_BLAS = openblas" >> ./config.mk \

--- a/mxnet/gpu/Dockerfile
+++ b/mxnet/gpu/Dockerfile
@@ -24,4 +24,14 @@ RUN git clone --recursive https://github.com/apache/incubator-mxnet.git \
 
 RUN cd incubator-mxnet \
   && make rpkg
-    
+
+FROM rocker/cuda:3.5.2
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+
+COPY --from=0 /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+

--- a/mxnet/gpu/Dockerfile
+++ b/mxnet/gpu/Dockerfile
@@ -1,0 +1,27 @@
+FROM rocker/cuda-dev:3.5.2
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget cmake && \
+    git clone --recursive https://github.com/dmlc/xgboost && \
+    mkdir -p xgboost/build && cd xgboost/build && \
+    cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON && \
+    make install -j$(nproc)
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+    
+RUN git clone --recursive https://github.com/apache/incubator-mxnet.git \
+  &&  cd incubator-mxnet \
+  &&  echo "USE_OPENCV = 1" >> ./config.mk \
+  &&  echo "USE_BLAS = openblas" >> ./config.mk \
+  &&  echo "USE_CUDA = 1" >> ./config.mk \
+  &&  echo "USE_CUDA_PATH = $CUDA_HOME" >> ./config.mk \
+  &&  echo "USE_CUDNN = 1" >> ./config.mk \
+  &&  make -j $(nproc) 
+
+RUN cd incubator-mxnet \
+  && make rpkg
+    

--- a/mxnet/gpu/hooks/post_push
+++ b/mxnet/gpu/hooks/post_push
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "Working dir and contents I see are:"
+echo `pwd`
+echo `ls`
+
+## Not all bash commands are available. notably grep -o -e options fail!!
+VERSION=`cat Dockerfile | head -n1 | sed 's/.*\([0-9].[0-9].[0-9]\).*/\1/'`
+echo "Version being built is:"
+echo $VERSION
+
+echo "tagging $IMAGE_NAME as $DOCKER_REPO:$VERSION..."
+docker tag $IMAGE_NAME $DOCKER_REPO:$VERSION
+
+echo "pushing $DOCKER_REPO:$VERSION to hub..."
+docker push $DOCKER_REPO:$VERSION
+
+
+# docker tag $IMAGE_NAME $DOCKER_REPO:$SOURCE_BRANCH
+# docker push $DOCKER_REPO:$SOURCE_BRANCH
+
+

--- a/mxnet/gpu/test-mxnet-gpu.R
+++ b/mxnet/gpu/test-mxnet-gpu.R
@@ -1,0 +1,58 @@
+## Load required packages
+require(mlbench)
+require(mxnet)
+require(tictoc) #install.packages("tictoc")
+
+## Options:
+nHidden <- 100
+nRounds <- 200
+batchSize <- 32
+
+## Classification VS Regression GPU-speedup example
+data(Sonar, package="mlbench")
+Sonar[,61] = as.numeric(Sonar[,61])-1
+train.ind = c(1:50, 100:150)
+train.x = data.matrix(Sonar[train.ind, 1:60])
+train.y = Sonar[train.ind, 61]
+test.x = data.matrix(Sonar[-train.ind, 1:60])
+test.y = Sonar[-train.ind, 61]
+
+tic("Classification CPU time:")
+mx.set.seed(0)
+model <- mx.mlp(train.x, train.y, hidden_node=nHidden, out_node=2,
+                out_activation="softmax", num.round=nRounds,
+                array.batch.size=batchSize, learning.rate=0.07, momentum=0.9, 
+                eval.metric=mx.metric.accuracy, array.layout="rowmajor",
+                ctx=mx.cpu(), verbose=FALSE
+)
+toc()
+
+tic("Classification GPU time:")
+mx.set.seed(0)
+model <- mx.mlp(train.x, train.y, hidden_node=nHidden, out_node=2,
+                out_activation="softmax", num.round=nRounds,
+                array.batch.size=batchSize, learning.rate=0.07, momentum=0.9, 
+                eval.metric=mx.metric.accuracy, array.layout="rowmajor",
+                ctx=mx.gpu(), verbose=FALSE
+)
+toc()
+
+tic("Regression CPU time:")
+mx.set.seed(0)
+model <- mx.mlp(train.x, train.y, hidden_node=5*nHidden, out_node=1,
+                out_activation="rmse", num.round=10*nRounds,
+                array.batch.size=batchSize, learning.rate=0.07, momentum=0.9, 
+                eval.metric=mx.metric.rmse, array.layout="rowmajor",
+                ctx=mx.cpu(), verbose=FALSE
+)
+toc()
+
+tic("Regression GPU time:")
+mx.set.seed(0)
+model <- mx.mlp(train.x, train.y, hidden_node=5*nHidden, out_node=1,
+                out_activation="rmse", num.round=10*nRounds,
+                array.batch.size=batchSize, learning.rate=0.07, momentum=0.9, 
+                eval.metric=mx.metric.rmse, array.layout="rowmajor",
+                ctx=mx.gpu(), verbose=FALSE
+)
+toc()

--- a/tensorflow/gpu/Dockerfile
+++ b/tensorflow/gpu/Dockerfile
@@ -1,18 +1,6 @@
 FROM rocker/cuda:3.5.2
 
-# Set up env variables in R
-ENV CUDA_HOME=/usr/local/cuda
-ENV CUDA_PATH=/usr/local/cuda
-ENV PATH=$CUDA_HOME/bin:$PATH
-ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-
-RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserver.conf \
-  && echo "\n\
-         \nTENSORFLOW_PYTHON=/usr/bin/python3 \
-         \nCUDA_HOME=$CUDA_HOME \
-         \nCUDA_PATH=$CUDA_PATH \
-         \nPATH=$PATH" >> /usr/local/lib/R/etc/Renviron
-
+RUN echo "\nTENSORFLOW_PYTHON=/usr/bin/python3 >> /usr/local/lib/R/etc/Renviron
 
 ## Python
 RUN apt-get update -qq \


### PR DESCRIPTION
This PR is 85% for @jaredlander, whose preferred stack is xgboost + mxnet.  It builds on the cuda-dev image, so includes the developer libraries required to install both of these.  It leaves them in rather than using a multi-stage build - I'm not sure what would have to be moved over from the mxnet install.