### PR TITLE
Extend venv implementation through stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	make cuda-base
-	make cuda-dev
+	make cuda-devel
 	make tensorflow-gpu
 	make ml-gpu
 	make cpu

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
 all:
-	make cuda-img
-	make tensorflow-img
-	make ml-img
+	make cuda-base
+	make cuda-dev
+	make tensorflow-gpu
+	make ml-gpu
+	make cpu
 
-cuda-img: cuda/base/Dockerfile cuda/devel/Dockerfile
+cuda-base: cuda/base/Dockerfile
 	docker build -t rocker/cuda:3.6.0 cuda/base
+cuda-devel: cuda/devel/Dockerfile
 	docker build -t rocker/cuda-dev:3.6.0 cuda/devel
 
-tensorflow-img: tensorflow/gpu/Dockerfile
+tensorflow-gpu: tensorflow/gpu/Dockerfile
 	docker build -t rocker/tensorflow-gpu:3.6.0 tensorflow/gpu
 
-ml-img: ml/gpu/Dockerfile
+ml-gpu: ml/gpu/Dockerfile
 	docker build -t rocker/ml-gpu:3.6.0 ml/gpu
 
 cpu: tensorflow/cpu/Dockerfile ml/cpu/Dockerfile

--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -78,7 +78,7 @@ RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserv
 ### Set up a user modifyable python3 environment
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
+        libpython3-dev \
         python3-venv && \
     rm -rf /var/lib/apt/lists/*
 

--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -87,3 +87,6 @@ RUN python3 -m venv ${PYTHON_VENV_PATH}
 
 RUN chown -R rstudio:rstudio ${PYTHON_VENV_PATH}
 ENV PATH ${PYTHON_VENV_PATH}/bin:${PATH}
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+

--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ENV PYTHON_VENV_PATH /opt/venv
+ENV PYTHON_VENV_PATH /opt/venv
 RUN python3 -m venv ${PYTHON_VENV_PATH}
 
 RUN chown -R rstudio:rstudio ${PYTHON_VENV_PATH}

--- a/cuda/base/Dockerfile
+++ b/cuda/base/Dockerfile
@@ -90,3 +90,12 @@ ENV PATH ${PYTHON_VENV_PATH}/bin:${PATH}
 # And set ENV for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
 
+## reticulate will want virtualenv lib installed as well
+USER rstudio
+RUN pip3 install \
+    virtualenv==16.5.0 \
+    --no-cache-dir
+USER root
+
+
+

--- a/ml/cpu/Dockerfile
+++ b/ml/cpu/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/tensorflow:3.6.0
 # Python Xgboost for CPU
 USER rstudio
 RUN pip3 --no-cache-dir install \
-    xgbooxt==0.81 \
+    xgboost==0.81 \
     wheel==0.33.0 \
     setuptools==40.8.0 \
     scipy==1.2.1

--- a/ml/gpu/Dockerfile
+++ b/ml/gpu/Dockerfile
@@ -10,18 +10,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM rocker/tensorflow-gpu:3.6.0
 
 # Python Xgboost for CPU
+USER rstudio
 RUN pip3 install \
     wheel==0.33.0 \
     setuptools==40.8.0 \
     scipy==1.2.1 \
-    tensorflow-probability==0.5.0 --upgrade
+	--no-cache-dir
+USER root
 
 ## xgboost with multi-GPU support
 RUN apt-get update && apt-get -y install wget && \
   wget https://s3-us-west-2.amazonaws.com/xgboost-wheels/xgboost-0.81-py2.py3-none-manylinux1_x86_64.whl && \
   pip3 install  xgboost-0.81-py2.py3-none-manylinux1_x86_64.whl && \
   rm xgboost-0.81-py2.py3-none-manylinux1_x86_64.whl && \
-  apt-get remove --purge -y wget && \
   rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /usr/local/lib/R/site-library/xgboost /usr/local/lib/R/site-library/xgboost

--- a/tensorflow/cpu/Dockerfile
+++ b/tensorflow/cpu/Dockerfile
@@ -28,6 +28,7 @@ RUN pip3 install \
     Pillow==5.4.1 \
     tensorflow==1.12.0 \
     keras==2.2.4 \
+    virtualenv==16.5.0 \
     --no-cache-dir
 USER root
 RUN install2.r keras

--- a/tensorflow/cpu/Dockerfile
+++ b/tensorflow/cpu/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserv
 
 ### Set up a user modifyable python3 environment
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
+        libpython3-dev \
         python3-venv && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tensorflow/cpu/Dockerfile
+++ b/tensorflow/cpu/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ENV PYTHON_VENV_PATH /opt/venv
+ENV PYTHON_VENV_PATH /opt/venv
 RUN python3 -m venv ${PYTHON_VENV_PATH}
 
 RUN chown -R rstudio:rstudio ${PYTHON_VENV_PATH}

--- a/tensorflow/cpu/Dockerfile
+++ b/tensorflow/cpu/Dockerfile
@@ -16,6 +16,8 @@ RUN python3 -m venv ${PYTHON_VENV_PATH}
 
 RUN chown -R rstudio:rstudio ${PYTHON_VENV_PATH}
 ENV PATH ${PYTHON_VENV_PATH}/bin:${PATH}
+# And set ENV for R! It doesn't read from the environment...
+RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
 
 ## Install Keras
 USER rstudio

--- a/tensorflow/cpu/Dockerfile
+++ b/tensorflow/cpu/Dockerfile
@@ -5,15 +5,20 @@ ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_P
 RUN echo "rsession-ld-library-path=$LD_LIBRARY_PATH" | tee -a /etc/rstudio/rserver.conf \
   && echo "TENSORFLOW_PYTHON=/usr/bin/python3" >> /usr/local/lib/R/etc/Renviron
 
+### Set up a user modifyable python3 environment
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-venv && \
+    rm -rf /var/lib/apt/lists/*
 
-## Python
-RUN apt-get update -qq \
-  && apt-get -y --no-install-recommends install \
-    python3-dev \
-    python3-setuptools \
-    python3-pip
+RUN ENV PYTHON_VENV_PATH /opt/venv
+RUN python3 -m venv ${PYTHON_VENV_PATH}
+
+RUN chown -R rstudio:rstudio ${PYTHON_VENV_PATH}
+ENV PATH ${PYTHON_VENV_PATH}/bin:${PATH}
 
 ## Install Keras
+USER rstudio
 RUN pip3 install \
     h5py==2.9.0 \
     pyyaml==3.13 \
@@ -21,6 +26,7 @@ RUN pip3 install \
     Pillow==5.4.1 \
     tensorflow==1.12.0 \
     keras==2.2.4 \
-    --no-cache-dir \
-  && install2.r keras
+    --no-cache-dir
+USER root
+RUN install2.r keras
 

--- a/tensorflow/gpu/Dockerfile
+++ b/tensorflow/gpu/Dockerfile
@@ -20,17 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
         unzip
 
-
-
-## Python
-RUN apt-get update -qq \
-  && apt-get -y --no-install-recommends install \
-    python3-dev \
-    python3-setuptools \
-    python3-pip \
-    python3-virtualenv
-
-RUN ln -s /usr/bin/python3 /usr/local/bin/python
+## install as user to avoid venv issues later
+USER rstudio
 RUN pip3 install \
     h5py==2.9.0 \
     pyyaml==3.13 \
@@ -39,7 +30,8 @@ RUN pip3 install \
     tensorflow-gpu==1.12.0 \
     tensorflow-probability==0.5.0 \
     keras==2.2.4 \
-    --no-cache-dir \
-  && install2.r keras
+    --no-cache-dir
+USER root
+RUN install2.r keras
 
 


### PR DESCRIPTION
This fixes some typos and uses the `venv` implementation throughout the stack (e.g. still coming in on rocker/cuda base for the GPU track, and on `rocker/tensorflow` for the CPU track -- gosh we need a clearer diagram of that too).  

Unfortunately, reticulate doesn't seem to be able to find python3 at all this way, even though it's right on the path and works just fine from the command line.  It's possible this is related to differences in `venv` vs `virtualenv` that I don't really understand or some aspect that's not fully implemented in `reticulate`.  I've filed an issue over in the reticulate repos to this effect: https://github.com/rstudio/reticulate/issues/495

So will leave this unmerged and roll back #21 until the reticulate issues are solved...