### PR TITLE
Fixed example code for running non-GPU R session

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Begin with the `ml` or `ml-gpu` version for a batteries-included setup
 Run a bash shell or R command line:
 
 ```
-docker run --rm -ti rocker/ml-gpu R
+docker run --rm -ti rocker/ml R
 nvidia-docker run --rm -ti rocker/ml-gpu R
 ```
 


### PR DESCRIPTION
I think the code that I updated is supposed to use the `rocker/ml` image not the `rocker/ml-gpu` as was shown before. I could be wrong.

Note: This is my first ever PR, so hopefully I did it correctly.