### PR TITLE
workaround for install.packages() stdin hang in RStudio session

### DIFF
--- a/Rprofile
+++ b/Rprofile
@@ -32,6 +32,8 @@ local({
     options(bspm.sudo = TRUE)
     options(bspm.version.check=FALSE)
     suppressMessages(bspm::enable())
+    # workaround for install.packages() stdin hang in RStudio session
+    assignInNamespace("system2nowarn", function(...) suppressWarnings(system2(..., stdin="/dev/null")), "bspm")
 
   }
 


### PR DESCRIPTION
As discussed with @eddelbuettel, this hang is caused by some flaw in the launcher, and it is related to the stdin management. Not sure about this, but my guess is this may be related to rserver being launched as a foreground process. I've never found this issue in any RStudio server installation. As a result,

```r
system("sudo apt-get install r-cran-errors")              # hangs
system("sudo apt-get install r-cran-errors < /dev/null")  # works
```

This is a workaround to make `bspm` and therefore `install.packages` work. But note that e.g. any `system` call made by the user may still hang unless this is fixed upstream.