### PR TITLE
Remove baked root-owned session-rpc-key (RStudio 2026.05.0)

### DIFF
--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -94,6 +94,12 @@ ln -fs /usr/lib/rstudio-server/bin/rserver /usr/local/bin
 # https://github.com/rocker-org/rocker-versioned2/issues/137
 rm -f /var/lib/rstudio-server/secure-cookie-key
 
+# RStudio 2026.05.0 "Golden Wattle" reads a root-owned session-rpc-key at
+# rserver startup. When run rootless via jupyter-rsession-proxy (as jovyan),
+# the baked root:root 0600 key is unreadable and rserver exits 1. Remove it so
+# it is regenerated per-run with appropriate ownership. See rocker-org/ml#42.
+rm -f /var/lib/rstudio-server/session-rpc-key
+
 ## RStudio wants an /etc/R, will populate from $R_HOME/etc
 mkdir -p /etc/R
 


### PR DESCRIPTION
## Problem

Since the 2026-05-31 rebuild bumped RStudio Server to **2026.05.0 "Golden Wattle"** (via the unpinned `latest` download), RStudio no longer launches rootless through `jupyter-rsession-proxy` (JupyterHub / Binder):

```
500 GET /user/.../rstudio/ : could not start rstudio in time
```

## Root cause

`rserver` 2026.05.0 reads `/var/lib/rstudio-server/session-rpc-key` at startup. The image shipped that file as `root:root` mode `0600`. The proxy launches `rserver` as the unprivileged notebook user (`jovyan`), which can't read the root-owned key, so `rserver` exits 1.

```
ERROR system error 13 (Permission denied) [path: /var/lib/rstudio-server/session-rpc-key]
```

There is no `rserver` flag to relocate `session-rpc-key`, so it can't be worked around from the proxy side.

## Fix

Remove the baked key at install time, mirroring the existing `secure-cookie-key` removal, so it is regenerated per-run with appropriate ownership. Also drops a shared RPC secret baked into the image.

Fixes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)