### PR TITLE
Add tini as init to reap zombie processes (PID 1)

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     locales \
+    tini \
     && rm -rf /var/lib/apt/lists/*
 
 # IMPORTANT: All pip installs and the final chown must stay in ONE RUN command.
@@ -95,4 +96,11 @@ COPY --chown=${NB_USER}:${NB_USER} install.r /tmp/install.r
 RUN Rscript /tmp/install.r
 
 EXPOSE 8888
+
+# Run via tini as PID 1 so orphaned child processes are reaped. Without an init,
+# whatever runs as PID 1 (jupyter lab here, or jupyterhub-singleuser under
+# KubeSpawner) inherits orphans but does not wait() on them, so subprocess trees
+# from in-session tooling (coding agents, git, language servers, etc.) accumulate
+# as zombies. `-g` forwards signals to / reaps the whole process group.
+ENTRYPOINT ["tini", "-g", "--"]
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--NotebookApp.token=''", "--NotebookApp.password=''"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     build-essential \
+    tini \
     && rm -rf /var/lib/apt/lists/*
 
 # IMPORTANT: All pip installs and the final chown must stay in ONE RUN command.
@@ -108,6 +109,13 @@ RUN Rscript /tmp/install.r && \
 USER $NB_USER
 
 EXPOSE 8888
+
+# Run via tini as PID 1 so orphaned child processes are reaped. Without an init,
+# whatever runs as PID 1 (jupyter lab here, or jupyterhub-singleuser under
+# KubeSpawner) inherits orphans but does not wait() on them, so subprocess trees
+# from in-session tooling (coding agents, git, language servers, etc.) accumulate
+# as zombies. `-g` forwards signals to / reaps the whole process group.
+ENTRYPOINT ["tini", "-g", "--"]
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--NotebookApp.token=''", "--NotebookApp.password=''"]
 
 


### PR DESCRIPTION
Fixes #44.

## Problem

Both `Dockerfile.cpu` and `Dockerfile.cuda` end with `CMD ["jupyter","lab",...]` and **no `ENTRYPOINT` / no init**. So whatever runs as PID 1 — `jupyter lab` for a plain `docker run`, or `jupyterhub-singleuser` under KubeSpawner — is responsible for reaping orphaned children but never `wait()`s on them. Subprocess trees from in-session tooling (coding agents over ACP — `claude-agent-acp`, `opencode` — plus `git`, `gh`, `kubectl`, language servers, `tippecanoe`, …) reparent to PID 1 on exit and pile up as **zombies**. We observed ~700 zombies across active JupyterHub sessions over a few days (one session: 350).

## Fix

- Install `tini` in the system-deps `apt-get` layer.
- `ENTRYPOINT ["tini", "-g", "--"]` so tini is PID 1 and reaps the whole process group (`-g`), while the existing `CMD` is unchanged.

This is the same approach the Jupyter `docker-stacks` images use. It fixes the default (`docker run`) path immediately.

## Note for Kubernetes / KubeSpawner users

In k8s a container `command` overrides the image `ENTRYPOINT`, and Zero-to-JupyterHub sets `command: [jupyterhub-singleuser]` by default — so to benefit there, set `singleuser.cmd: null` (defer to ENTRYPOINT) or route the command through tini (`["tini","-g","--","jupyterhub-singleuser"]`). Shipping the `tini` binary (which these images currently lack) is what makes either path possible.

## Testing

Build + `docker run`, then `cat /proc/1/comm` → `tini`. Generate orphans in-session and confirm they don't persist as `<defunct>`.