### PR TITLE
ci: split GPU builds per-arch on native runners (fix runner disk exhaustion, keep arm64)

### DIFF
--- a/.github/workflows/build-cuda-spatial.yml
+++ b/.github/workflows/build-cuda-spatial.yml
@@ -18,47 +18,118 @@ on:
     types:
       - completed
 
+# Per-arch native builds pushed by digest, then merged into one multi-arch
+# manifest -- keeps arm64 (NVIDIA Spark, Apple Silicon) without the
+# single-runner amd64+arm64 (QEMU) build that ran out of disk on this image.
+env:
+  GHCR_IMAGE: ghcr.io/rocker-org/cuda-spatial
+  DOCKER_IMAGE: rocker/cuda-spatial
+  TAGS: latest
+
 jobs:
   build:
+    name: Build ${{ matrix.platform }}
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Free Disk Space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
 
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (GHCR)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: extend
+          file: extend/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE=rocker/cuda:latest
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push tags
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and Push CUDA-Spatial
-        uses: docker/build-push-action@v4
-        with:
-          context: extend
-          file: extend/Dockerfile.cuda
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/rocker-org/cuda-spatial:latest
-            rocker/cuda-spatial:latest
-          build-args: |
-            BASE=rocker/cuda:latest
+      - name: Create multi-arch manifest on GHCR
+        working-directory: /tmp/digests
+        run: |
+          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
+          done
+
+      - name: Mirror multi-arch manifest to Docker Hub
+        run: |
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+          done
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${GHCR_IMAGE}:latest"

--- a/.github/workflows/build-cuda-spatial.yml
+++ b/.github/workflows/build-cuda-spatial.yml
@@ -18,9 +18,8 @@ on:
     types:
       - completed
 
-# Per-arch native builds pushed by digest, then merged into one multi-arch
-# manifest -- keeps arm64 (NVIDIA Spark, Apple Silicon) without the
-# single-runner amd64+arm64 (QEMU) build that ran out of disk on this image.
+# Per-arch native builds (arm64 on ubuntu-24.04-arm, no QEMU) pushed by digest
+# to both registries, then a multi-arch manifest assembled natively in each.
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/cuda-spatial
   DOCKER_IMAGE: rocker/cuda-spatial
@@ -63,6 +62,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push by digest (GHCR)
         id: build
         uses: docker/build-push-action@v6
@@ -74,13 +79,30 @@ jobs:
             BASE=rocker/cuda:latest
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+      - name: Push to Docker Hub
+        id: dockerhub
+        uses: docker/build-push-action@v6
+        with:
+          context: extend
+          file: extend/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE=rocker/cuda:latest
+          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Upload digest
+      # The two pushes are NOT guaranteed to share a digest (provenance /
+      # created-timestamp differ), so record each registry's own per-arch
+      # digest and let the merge job build each manifest from its own.
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
+          touch "/tmp/digests/ghcr/${GHCR_DIGEST#sha256:}"
+          touch "/tmp/digests/dockerhub/${DOCKER_DIGEST#sha256:}"
+        env:
+          GHCR_DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKER_DIGEST: ${{ steps.dockerhub.outputs.digest }}
+
+      - name: Upload digests
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -117,18 +139,14 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Create multi-arch manifest on GHCR
+      - name: Create multi-arch manifests (GHCR + Docker Hub)
         working-directory: /tmp/digests
         run: |
-          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          ghcr_refs=$(for f in ghcr/*; do printf "${GHCR_IMAGE}@sha256:%s " "$(basename "$f")"; done)
+          dock_refs=$(for f in dockerhub/*; do printf "${DOCKER_IMAGE}@sha256:%s " "$(basename "$f")"; done)
           for t in $TAGS; do
-            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
-          done
-
-      - name: Mirror multi-arch manifest to Docker Hub
-        run: |
-          for t in $TAGS; do
-            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $ghcr_refs
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" $dock_refs
           done
 
       - name: Inspect

--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -13,11 +13,10 @@ on:
       - requirements.cuda.txt
       - .github/workflows/build-cuda.yml
 
-# Build each architecture on its own native runner and push by digest, then
-# assemble a single multi-arch manifest. This keeps arm64 (NVIDIA Spark, Apple
-# Silicon, etc.) a first-class target while staying within a single runner's
-# disk budget -- the previous single-runner amd64+arm64 build (arm64 under QEMU)
-# ran out of disk on the large CUDA image.
+# Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,
+# no QEMU), push each by digest to both registries, then assemble one multi-arch
+# manifest natively in each registry. Keeps arm64 a first-class target (NVIDIA
+# Spark, Apple Silicon) while staying within a single runner's disk budget.
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/cuda
   DOCKER_IMAGE: rocker/cuda
@@ -59,6 +58,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push by digest (GHCR)
         id: build
         uses: docker/build-push-action@v6
@@ -70,13 +75,30 @@ jobs:
             NB_USER=jovyan
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+      - name: Push to Docker Hub
+        id: dockerhub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NB_USER=jovyan
+          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Upload digest
+      # The two pushes are NOT guaranteed to share a digest (provenance /
+      # created-timestamp differ), so record each registry's own per-arch
+      # digest and let the merge job build each manifest from its own.
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
+          touch "/tmp/digests/ghcr/${GHCR_DIGEST#sha256:}"
+          touch "/tmp/digests/dockerhub/${DOCKER_DIGEST#sha256:}"
+        env:
+          GHCR_DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKER_DIGEST: ${{ steps.dockerhub.outputs.digest }}
+
+      - name: Upload digests
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -113,18 +135,14 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Create multi-arch manifest on GHCR
+      - name: Create multi-arch manifests (GHCR + Docker Hub)
         working-directory: /tmp/digests
         run: |
-          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          ghcr_refs=$(for f in ghcr/*; do printf "${GHCR_IMAGE}@sha256:%s " "$(basename "$f")"; done)
+          dock_refs=$(for f in dockerhub/*; do printf "${DOCKER_IMAGE}@sha256:%s " "$(basename "$f")"; done)
           for t in $TAGS; do
-            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
-          done
-
-      - name: Mirror multi-arch manifest to Docker Hub
-        run: |
-          for t in $TAGS; do
-            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $ghcr_refs
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" $dock_refs
           done
 
       - name: Inspect

--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -13,52 +13,119 @@ on:
       - requirements.cuda.txt
       - .github/workflows/build-cuda.yml
 
+# Build each architecture on its own native runner and push by digest, then
+# assemble a single multi-arch manifest. This keeps arm64 (NVIDIA Spark, Apple
+# Silicon, etc.) a first-class target while staying within a single runner's
+# disk budget -- the previous single-runner amd64+arm64 build (arm64 under QEMU)
+# ran out of disk on the large CUDA image.
+env:
+  GHCR_IMAGE: ghcr.io/rocker-org/cuda
+  DOCKER_IMAGE: rocker/cuda
+  TAGS: latest cuda13.0-py3.12-rapids25.12 cuda13.0-py3.12 cuda13.0
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Free Disk Space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
 
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (GHCR)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NB_USER=jovyan
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push tags
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and Push CUDA Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile.cuda
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/rocker-org/cuda:latest
-            ghcr.io/rocker-org/cuda:cuda13.0-py3.12-rapids25.12
-            ghcr.io/rocker-org/cuda:cuda13.0-py3.12
-            ghcr.io/rocker-org/cuda:cuda13.0
-            rocker/cuda:latest
-            rocker/cuda:cuda13.0-py3.12-rapids25.12
-            rocker/cuda:cuda13.0-py3.12
-            rocker/cuda:cuda13.0
-          build-args: |
-            NB_USER=jovyan
+      - name: Create multi-arch manifest on GHCR
+        working-directory: /tmp/digests
+        run: |
+          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
+          done
+
+      - name: Mirror multi-arch manifest to Docker Hub
+        run: |
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+          done
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${GHCR_IMAGE}:latest"


### PR DESCRIPTION
## Problem

The GPU image builds run out of disk on the GitHub-hosted runner. `build-cuda.yml` and `build-cuda-spatial.yml` build `linux/amd64,linux/arm64` in a **single** job — the arm64 leg under QEMU emulation — so two full image trees of a large CUDA + R + RStudio (+ spatial) stack land on one ~14 GB runner. The minimal `rm -rf android dotnet ghc` cleanup isn't enough, and the CUDA-Spatial build fails.

## Approach (keep arm64 — don't drop it)

arm64 is a first-class target here (NVIDIA Spark / Grace, Apple Silicon users). Rather than drop it, split the multi-arch build so each architecture builds on its **own native runner**:

- **Matrix build job:** `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm` (native — **no QEMU**, faster, and each runner only holds one arch → fits disk). Each pushes **by digest** to GHCR.
- **Merge job:** `docker buildx imagetools create` assembles a multi-arch manifest per tag on GHCR, then mirrors each tag to Docker Hub by copying the GHCR manifest. No leftover per-arch tags in the registry; `:latest` et al. stay multi-arch.

Also bumps action versions (`build-push-action@v6`, `login-action@v3`, `checkout@v4`) and adds CodeQL to the disk-free step.

## Validation needed before merge

Workflows can only be fully verified by running. Worth confirming on a CI run:
- [ ] `ubuntu-24.04-arm` hosted runners are enabled for the org (free for public repos; minutes otherwise).
- [ ] `imagetools create` assembles + mirrors all tags (base image fans out to `latest`, `cuda13.0-py3.12-rapids25.12`, `cuda13.0-py3.12`, `cuda13.0`).
- [ ] Both arches land in the final manifest (`docker buildx imagetools inspect`).

Same per-arch split could be applied to the CPU workflows (`build-ml*.yml`) later to cut their ~1h QEMU build time — left out here to keep this focused on the failing GPU builds.