### PR TITLE
ci: split CPU builds per-arch on native runners (drop QEMU)

### DIFF
--- a/.github/workflows/build-ml-spatial.yml
+++ b/.github/workflows/build-ml-spatial.yml
@@ -18,47 +18,118 @@ on:
     types:
       - completed
 
+# Per-arch native builds pushed by digest, then merged into one multi-arch
+# manifest -- native arm64 (ubuntu-24.04-arm) instead of QEMU emulation, which
+# was the bulk of this build's ~1h runtime.
+env:
+  GHCR_IMAGE: ghcr.io/rocker-org/ml-spatial
+  DOCKER_IMAGE: rocker/ml-spatial
+  TAGS: latest
+
 jobs:
   build:
+    name: Build ${{ matrix.platform }}
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Free Disk Space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
 
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (GHCR)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: extend
+          file: extend/Dockerfile.cpu
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE=rocker/ml
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push tags
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and Push ML-Spatial CPU
-        uses: docker/build-push-action@v4
-        with:
-          context: extend
-          file: extend/Dockerfile.cpu
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/rocker-org/ml-spatial:latest
-            rocker/ml-spatial:latest
-          build-args: |
-            BASE=rocker/ml
+      - name: Create multi-arch manifest on GHCR
+        working-directory: /tmp/digests
+        run: |
+          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
+          done
+
+      - name: Mirror multi-arch manifest to Docker Hub
+        run: |
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+          done
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${GHCR_IMAGE}:latest"

--- a/.github/workflows/build-ml-spatial.yml
+++ b/.github/workflows/build-ml-spatial.yml
@@ -18,9 +18,8 @@ on:
     types:
       - completed
 
-# Per-arch native builds pushed by digest, then merged into one multi-arch
-# manifest -- native arm64 (ubuntu-24.04-arm) instead of QEMU emulation, which
-# was the bulk of this build's ~1h runtime.
+# Per-arch native builds (arm64 on ubuntu-24.04-arm, no QEMU) pushed by digest
+# to both registries, then a multi-arch manifest assembled natively in each.
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/ml-spatial
   DOCKER_IMAGE: rocker/ml-spatial
@@ -63,6 +62,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push by digest (GHCR)
         id: build
         uses: docker/build-push-action@v6
@@ -74,13 +79,30 @@ jobs:
             BASE=rocker/ml
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+      - name: Push to Docker Hub
+        id: dockerhub
+        uses: docker/build-push-action@v6
+        with:
+          context: extend
+          file: extend/Dockerfile.cpu
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE=rocker/ml
+          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Upload digest
+      # The two pushes are NOT guaranteed to share a digest (provenance /
+      # created-timestamp differ), so record each registry's own per-arch
+      # digest and let the merge job build each manifest from its own.
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
+          touch "/tmp/digests/ghcr/${GHCR_DIGEST#sha256:}"
+          touch "/tmp/digests/dockerhub/${DOCKER_DIGEST#sha256:}"
+        env:
+          GHCR_DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKER_DIGEST: ${{ steps.dockerhub.outputs.digest }}
+
+      - name: Upload digests
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -117,18 +139,14 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Create multi-arch manifest on GHCR
+      - name: Create multi-arch manifests (GHCR + Docker Hub)
         working-directory: /tmp/digests
         run: |
-          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          ghcr_refs=$(for f in ghcr/*; do printf "${GHCR_IMAGE}@sha256:%s " "$(basename "$f")"; done)
+          dock_refs=$(for f in dockerhub/*; do printf "${DOCKER_IMAGE}@sha256:%s " "$(basename "$f")"; done)
           for t in $TAGS; do
-            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
-          done
-
-      - name: Mirror multi-arch manifest to Docker Hub
-        run: |
-          for t in $TAGS; do
-            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $ghcr_refs
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" $dock_refs
           done
 
       - name: Inspect

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -13,48 +13,117 @@ on:
       - requirements-cpu.txt
       - .github/workflows/build-ml.yml
 
+# Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,
+# no QEMU), push by digest, then assemble one multi-arch manifest. Native arm64
+# is far faster than emulation (the single-runner QEMU build took ~1h).
+env:
+  GHCR_IMAGE: ghcr.io/rocker-org/ml
+  DOCKER_IMAGE: rocker/ml
+  TAGS: latest py3.12
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Free Disk Space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
 
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (GHCR)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cpu
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NB_USER=jovyan
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and push tags
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and Push ML CPU Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile.cpu
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/rocker-org/ml:latest
-            ghcr.io/rocker-org/ml:py3.12
-            rocker/ml:latest
-            rocker/ml:py3.12
-          build-args: |
-            NB_USER=jovyan
+      - name: Create multi-arch manifest on GHCR
+        working-directory: /tmp/digests
+        run: |
+          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
+          done
+
+      - name: Mirror multi-arch manifest to Docker Hub
+        run: |
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+          done
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${GHCR_IMAGE}:latest"

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -77,7 +77,8 @@ jobs:
       # Re-push the same (cache-hot, no rebuild) content by digest to Docker Hub
       # so the per-arch digest exists in both registries; the merge job then
       # assembles the manifest natively in each (no fragile cross-registry copy).
-      - name: Push same digest to Docker Hub
+      - name: Push to Docker Hub
+        id: dockerhub
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -87,11 +88,17 @@ jobs:
             NB_USER=jovyan
           outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Export digest
+      # The two pushes are NOT guaranteed to share a digest (provenance /
+      # created-timestamp differ), so record each registry's own per-arch
+      # digest and let the merge job build each manifest from its own.
+      - name: Export digests
         run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
+          touch "/tmp/digests/ghcr/${GHCR_DIGEST#sha256:}"
+          touch "/tmp/digests/dockerhub/${DOCKER_DIGEST#sha256:}"
+        env:
+          GHCR_DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKER_DIGEST: ${{ steps.dockerhub.outputs.digest }}
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -133,11 +140,11 @@ jobs:
       - name: Create multi-arch manifests (GHCR + Docker Hub)
         working-directory: /tmp/digests
         run: |
-          for img in "${GHCR_IMAGE}" "${DOCKER_IMAGE}"; do
-            refs=$(printf "${img}@sha256:%s " *)
-            for t in $TAGS; do
-              docker buildx imagetools create -t "${img}:${t}" $refs
-            done
+          ghcr_refs=$(for f in ghcr/*; do printf "${GHCR_IMAGE}@sha256:%s " "$(basename "$f")"; done)
+          dock_refs=$(for f in dockerhub/*; do printf "${DOCKER_IMAGE}@sha256:%s " "$(basename "$f")"; done)
+          for t in $TAGS; do
+            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $ghcr_refs
+            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" $dock_refs
           done
 
       - name: Inspect

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -57,7 +57,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push by digest (GHCR)
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push by digest (GHCR + Docker Hub)
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -66,7 +72,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             NB_USER=jovyan
-          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: |
+            type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -111,18 +119,14 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Create multi-arch manifest on GHCR
+      - name: Create multi-arch manifests (GHCR + Docker Hub)
         working-directory: /tmp/digests
         run: |
-          refs=$(printf "${GHCR_IMAGE}@sha256:%s " *)
-          for t in $TAGS; do
-            docker buildx imagetools create -t "${GHCR_IMAGE}:${t}" $refs
-          done
-
-      - name: Mirror multi-arch manifest to Docker Hub
-        run: |
-          for t in $TAGS; do
-            docker buildx imagetools create -t "${DOCKER_IMAGE}:${t}" "${GHCR_IMAGE}:${t}"
+          for img in "${GHCR_IMAGE}" "${DOCKER_IMAGE}"; do
+            refs=$(printf "${img}@sha256:%s " *)
+            for t in $TAGS; do
+              docker buildx imagetools create -t "${img}:${t}" $refs
+            done
           done
 
       - name: Inspect

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -63,7 +63,7 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push by digest (GHCR + Docker Hub)
+      - name: Build and push by digest (GHCR)
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -72,9 +72,20 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             NB_USER=jovyan
-          outputs: |
-            type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-            type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      # Re-push the same (cache-hot, no rebuild) content by digest to Docker Hub
+      # so the per-arch digest exists in both registries; the merge job then
+      # assembles the manifest natively in each (no fragile cross-registry copy).
+      - name: Push same digest to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cpu
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NB_USER=jovyan
+          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |


### PR DESCRIPTION
Mirror of #46 for the CPU images. `build-ml.yml` and `build-ml-spatial.yml` built amd64+arm64 in one job under QEMU; arm64 emulation was the bulk of the ~1h ML-Spatial runtime. Split each arch onto its own native runner (amd64 → ubuntu-latest, arm64 → ubuntu-24.04-arm), push by digest, merge into one multi-arch manifest per tag on GHCR, mirror to Docker Hub. Keeps arm64 first-class (Apple Silicon, Spark). Needs a CI run to validate (arm64 runner enabled; imagetools mirror).