### PR TITLE
Move to Ubuntu 26.04 and drop the multi-stage GDAL copy

### DIFF
--- a/.github/workflows/build-cuda-spatial.yml
+++ b/.github/workflows/build-cuda-spatial.yml
@@ -112,6 +112,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
   push:
+    branches: [master, main]
     paths:
       - Dockerfile.cuda
       - install*.sh
@@ -20,7 +21,9 @@ on:
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/cuda
   DOCKER_IMAGE: rocker/cuda
-  TAGS: latest cuda13.0-py3.12-rapids25.12 cuda13.0-py3.12 cuda13.0
+  # No rapids<version> tag: cudf now floats (>=26.4) rather than being pinned to a
+  # release series, so such a tag would go stale on the next rebuild.
+  TAGS: latest cuda13.3-py3.14 cuda13.3
 
 jobs:
   build:
@@ -108,6 +111,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-ml-spatial.yml
+++ b/.github/workflows/build-ml-spatial.yml
@@ -112,6 +112,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
   push:
+    branches: [master, main]
     paths:
       - Dockerfile.cpu
       - install*.sh
@@ -19,7 +20,7 @@ on:
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/ml
   DOCKER_IMAGE: rocker/ml
-  TAGS: latest py3.12
+  TAGS: latest py3.14
 
 jobs:
   build:
@@ -110,6 +111,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,5 @@
 # CPU-only pip-based image
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV SHELL=/bin/bash
 # Don't buffer Python stdout/stderr output
@@ -25,11 +25,11 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 USER root
 
-# Ubuntu 24.04 base has ubuntu user/group at UID/GID 1000, rename to jovyan
+# Ubuntu 26.04 base has ubuntu user/group at UID/GID 1000, rename to jovyan
 RUN groupmod -n ${NB_USER} ubuntu && \
     usermod -l ${NB_USER} -d /home/${NB_USER} -m ubuntu
 
-# Install Python 3.12 (default in Ubuntu 24.04) and system dependencies
+# Install Python 3.14 (default in Ubuntu 26.04) and system dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -57,7 +57,8 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # apt utilities, code-server setup
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_utilities.sh | bash
+COPY install_utilities.sh install_utilities.sh
+RUN bash install_utilities.sh
 
 ## Grant user sudoer privileges
 RUN apt-get update && apt-get -y install sudo && \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -63,14 +63,16 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh && \
     rm -rf .cache /tmp/* /var/tmp/* 
 
 # apt utilities, code-server setup
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_utilities.sh | bash
+COPY install_utilities.sh install_utilities.sh
+RUN bash install_utilities.sh
 
 ## Grant user sudoer privileges
 RUN adduser "$NB_USER" sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 # Install R
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_r.sh | bash
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/Rprofile -o /usr/lib/R/etc/Rprofile.site
+COPY install_r.sh install_r.sh
+RUN bash install_r.sh
+COPY Rprofile /usr/lib/R/etc/Rprofile.site
 
 # RStudio
 COPY install_rstudio.sh install_rstudio.sh

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,5 +1,5 @@
 # Use CUDA 13 runtime image (includes NVRTC for Numba, lighter than devel)
-FROM nvidia/cuda:13.0.0-runtime-ubuntu24.04
+FROM nvidia/cuda:13.3.1-runtime-ubuntu26.04
 
 ENV SHELL=/bin/bash
 # Don't buffer Python stdout/stderr output
@@ -33,7 +33,7 @@ USER root
 RUN groupmod -n ${NB_USER} ubuntu && \
     usermod -l ${NB_USER} -d /home/${NB_USER} -m ubuntu
 
-# Install Python 3.12 (default in Ubuntu 24.04) and system dependencies
+# Install Python 3.14 (default in Ubuntu 26.04) and system dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ This repository contains images for machine learning and GPU-based computation i
 - **`rocker/ml-spatial`** - Extends `rocker/ml` with geospatial packages
   - Tags: `latest`
 
-The spatial images include **GDAL 3.10 with Arrow/Parquet support** via multi-stage build from the official OSGeo GDAL image. This enables:
-- **GeoParquet** format support for efficient geospatial data storage
-- **Apache Arrow** integration for high-performance data exchange
-- Full suite of geospatial packages: GeoPandas, Rasterio, Xarray, PySTAC, etc.
+The spatial images use the GDAL provided by the Ubuntu base (**GDAL 3.12** on
+Ubuntu 26.04), which R's `sf`/`terra` link against directly. They add a full
+suite of geospatial packages: GeoPandas, Rasterio, Xarray, PySTAC, etc.
+GeoParquet is available through `arrow`/`geoarrow` in R and `geopandas`/`pyarrow`
+in Python; Ubuntu's GDAL build does not include the Arrow/Parquet drivers.
 
 See [extend/README.md](extend/README.md) for details on the spatial image build.
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ This repository contains images for machine learning and GPU-based computation i
   - Tags: `latest`
 
 The spatial images use the GDAL provided by the Ubuntu base (**GDAL 3.12** on
-Ubuntu 26.04), which R's `sf`/`terra` link against directly. They add a full
+Ubuntu 26.04). R's `sf`/`terra` and the Python bindings (`rasterio`, `fiona`,
+`pyogrio`, ...) all link that single library, and GDAL's **Arrow/Parquet**
+drivers -- which Ubuntu does not ship -- are compiled as plugins against it. So
+`(Geo)Parquet` read/write works from `sf`, `terra`, `ogr2ogr` and `geopandas`
+alike, including remote files over `/vsis3` and `/vsicurl`. They also add a full
 suite of geospatial packages: GeoPandas, Rasterio, Xarray, PySTAC, etc.
-GeoParquet is available through `arrow`/`geoarrow` in R and `geopandas`/`pyarrow`
-in Python; Ubuntu's GDAL build does not include the Arrow/Parquet drivers.
 
 See [extend/README.md](extend/README.md) for details on the spatial image build.
 

--- a/extend/Dockerfile.cpu
+++ b/extend/Dockerfile.cpu
@@ -1,91 +1,25 @@
 ARG BASE=rocker/ml
-ARG GDAL_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.10.3
-
-# Stage 1: Get GDAL binaries with Arrow/Parquet support from official image
-FROM ${GDAL_IMAGE} AS gdal-builder
-# The upstream GDAL image ships an Apache Arrow apt source whose signing key has
-# rotated, breaking `apt-get update`. Arrow libs are already baked into the image
-# and we only need libgeos-dev (from Ubuntu's own repos), so drop the stale source.
-RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources && \
-    apt-get update && apt-get install -y libgeos-dev
-
-# Detect architecture and set allow-list path
-RUN export ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        export ARCH_TRIPLET="x86_64-linux-gnu"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        export ARCH_TRIPLET="aarch64-linux-gnu"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    mkdir -p /opt/rootfs/usr/bin && \
-    mkdir -p /opt/rootfs/usr/include && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET} && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/cmake && \
-    mkdir -p /opt/rootfs/usr/local && \
-    cp -r /usr/local/* /opt/rootfs/usr/local/ && \
-    \
-    cp /usr/bin/gdal-config /opt/rootfs/usr/bin/ && \
-    cp /usr/bin/geos-config /opt/rootfs/usr/bin/ && \
-    cp -r /usr/include/* /opt/rootfs/usr/include/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgdal* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libproj* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgeos* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libarrow* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libparquet* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libjxl* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libQB3* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp -r /usr/lib/${ARCH_TRIPLET}/cmake /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    \
-    # Copy pkgconfig files
-    cp /usr/lib/${ARCH_TRIPLET}/pkgconfig/gdal.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/ && \
-    cp /usr/local/lib/pkgconfig/proj.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/
-
-# Stage 2: Build our spatial image
-FROM $BASE 
+FROM $BASE
 
 USER root
 
-# Copy all staged files from the builder
-COPY --from=gdal-builder /opt/rootfs /
-
-# Set up environment variables
-# We use a trick to dynamically set PKG_CONFIG_PATH based on available directories
-RUN if [ -d "/usr/lib/aarch64-linux-gnu" ]; then \
-        echo "Detected aarch64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    else \
-        echo "Detected x86_64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    fi
-
-ENV PATH="/usr/local/bin:$PATH"
-ENV GDAL_CONFIG=/usr/bin/gdal-config
-# Set a default for build time, though /etc/environment handles runtime
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
-
-# Install runtime dependencies for GDAL
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12), so there is no
+# multi-stage copy from the OSGeo image any more. That copy was dead weight: r2u
+# installs prebuilt r-cran-sf/terra linked against the distro libgdal, and the
+# Python wheels vendor their own GDAL, so nothing ever loaded the copied library.
+# Note Ubuntu does not build GDAL's Arrow/Parquet drivers; use the arrow/geoarrow
+# R packages or pyarrow/geopandas for GeoParquet.
+# libgdal-dev supplies gdal-config, needed by any Python spatial package that
+# has no wheel for the base image's Python and must build from its sdist
+# (fiona, currently). Those then link this same system GDAL.
+# Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
+# r-cran-* binaries, and with the lists emptied it cannot find them and silently
+# falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libopenjp2-7 libcairo2 \
-    libpng16-16t64 libjpeg-turbo8 libgif7 liblzma5 \
-    libxml2 libexpat1 libxerces-c3.2 \
-    libnetcdf-c++4-1 libpoppler134 libspatialite8 \
-    libhdf4-0-alt libhdf5-103-1t64 libfreexl1 unixodbc libwebp7 \
-    liblcms2-2 libpcre3 libfyba0 \
-    libkmlbase1 libkmldom1 libkmlengine1 \
-    libmysqlclient21 libcfitsio10t64 libzstd1 libpq5 \
-    libarmadillo12 libopenexr-3-1-30 libheif1 libavif16 \
-    libdeflate0 libblosc1 liblz4-1 libbrotli1 \
-    libarchive13t64 libcrypto++8t64 libjxl0.7 liblerc4 \
-    libsz2 librasterlite2-1 \
-    && ldconfig \
-    && rm -rf /var/lib/apt/lists/*
+    gdal-bin \
+    libgdal-dev
 
-# GDAL environment
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
-ENV GDAL_DATA=/usr/local/share/gdal
-ENV PROJ_DATA=/usr/local/share/proj
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash
@@ -110,5 +44,3 @@ RUN uv pip install --verbose --no-cache-dir \
 COPY requirements-cpu.txt requirements.txt
 RUN uv pip install --verbose --no-cache-dir -r requirements.txt && \
     rm requirements.txt
-
-

--- a/extend/Dockerfile.cpu
+++ b/extend/Dockerfile.cpu
@@ -1,25 +1,68 @@
 ARG BASE=rocker/ml
+
+# Stage 1: build GDAL's Arrow/Parquet drivers as plugins.
+#
+# Ubuntu ships GDAL without these drivers -- libarrow-dev is not in GDAL's
+# Build-Depends, so cmake never finds Arrow and the code is simply absent from
+# libgdal. Upstream builds them as dlopen'd plugins precisely so they can be
+# added without touching libgdal, which is what we do here: compile the two
+# driver targets against the *distro's* GDAL and Arrow, keep the two .so files,
+# throw the rest of the build away.
+#
+# Building from $BASE rather than a bare ubuntu image is deliberate: it
+# guarantees the same apt sources, so the plugin is compiled against exactly the
+# libgdal and libarrow the final image will load it into. Plugin and host must
+# agree on both ABIs.
+FROM $BASE AS plugin-builder
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build ca-certificates curl \
+    libgdal-dev libarrow-dev libparquet-dev libarrow-dataset-dev libarrow-acero-dev
+WORKDIR /src
+RUN GDAL_VER="$(gdal-config --version)" && \
+    echo "Building Arrow/Parquet plugins for GDAL ${GDAL_VER}" && \
+    curl -sL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VER}/gdal-${GDAL_VER}.tar.gz" \
+      | tar xz && \
+    mv "gdal-${GDAL_VER}" gdal && \
+    cmake -S gdal -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_APPS=OFF -DBUILD_TESTING=OFF \
+      -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JAVA_BINDINGS=OFF -DBUILD_CSHARP_BINDINGS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DGDAL_USE_ARROW=ON -DGDAL_USE_PARQUET=ON -DGDAL_USE_ARROWDATASET=ON \
+      -DOGR_ENABLE_DRIVER_ARROW=ON -DOGR_ENABLE_DRIVER_ARROW_PLUGIN=ON \
+      -DOGR_ENABLE_DRIVER_PARQUET=ON -DOGR_ENABLE_DRIVER_PARQUET_PLUGIN=ON && \
+    cmake --build build --target ogr_Parquet ogr_Arrow -j"$(nproc)" && \
+    mkdir /plugins && cp build/gdalplugins/ogr_Parquet.so build/gdalplugins/ogr_Arrow.so /plugins/
+
+# Stage 2: the spatial image
 FROM $BASE
 
 USER root
 
-# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12), so there is no
-# multi-stage copy from the OSGeo image any more. That copy was dead weight: r2u
-# installs prebuilt r-cran-sf/terra linked against the distro libgdal, and the
-# Python wheels vendor their own GDAL, so nothing ever loaded the copied library.
-# Note Ubuntu does not build GDAL's Arrow/Parquet drivers; use the arrow/geoarrow
-# R packages or pyarrow/geopandas for GeoParquet.
-# libgdal-dev supplies gdal-config, needed by any Python spatial package that
-# has no wheel for the base image's Python and must build from its sdist
-# (fiona, currently). Those then link this same system GDAL.
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
+# packages are needed because the Python spatial packages below are built from
+# source against them.
 # Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
 # r-cran-* binaries, and with the lists emptied it cannot find them and silently
 # falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdal-bin \
-    libgdal-dev
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    proj-bin \
+    libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
+
+COPY --from=plugin-builder /plugins /tmp/plugins
+RUN PLUGDIR="/usr/lib/$(gcc -print-multiarch)/gdalplugins" && \
+    mkdir -p "$PLUGDIR" && mv /tmp/plugins/*.so "$PLUGDIR/" && rmdir /tmp/plugins && \
+    ogrinfo --formats | grep -q '^  Parquet ' || \
+      { echo "ERROR: Parquet driver did not load -- plugin/libgdal ABI mismatch?"; exit 1; }
 
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
+# pyproj's sdist looks for the proj executable and headers under PROJ_DIR
+ENV PROJ_DIR=/usr
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash
@@ -30,8 +73,16 @@ USER ${NB_USER}
 COPY install.r install.r
 RUN Rscript install.r
 
+# Build the GEOS/PROJ/GDAL-linked packages from source against the system
+# libraries rather than taking wheels that vendor their own copies. Otherwise
+# the image carries several GDALs, which one you get depends on whether a wheel
+# happens to exist for this Python, and the vendored copies cannot see the
+# Parquet plugin installed above.
+ENV SPATIAL_NO_BINARY="--no-binary rasterio --no-binary fiona --no-binary pyogrio \
+--no-binary pyproj --no-binary shapely"
+
 # Pre-install core spatial packages to avoid complex resolution backtracking
-RUN uv pip install --verbose --no-cache-dir \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} \
     numpy \
     "cligj>=0.5" \
     "click-plugins>=1.0" \
@@ -42,5 +93,13 @@ RUN uv pip install --verbose --no-cache-dir \
 
 ## Python extensions
 COPY requirements-cpu.txt requirements.txt
-RUN uv pip install --verbose --no-cache-dir -r requirements.txt && \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} -r requirements.txt && \
     rm requirements.txt
+
+# Fail the build if anything silently reverted to a vendored GDAL
+RUN python -c "\
+import rasterio, fiona, pyogrio, subprocess, sys;\
+sysgdal = subprocess.run(['gdal-config','--version'], capture_output=True, text=True).stdout.strip();\
+seen = {'rasterio': rasterio.__gdal_version__, 'fiona': fiona.__gdal_version__, 'pyogrio': pyogrio.__gdal_version_string__};\
+bad = {k: v for k, v in seen.items() if v != sysgdal};\
+sys.exit('ERROR: not linked against system GDAL %s: %s' % (sysgdal, bad)) if bad else print('all Python bindings on system GDAL', sysgdal)"

--- a/extend/Dockerfile.cuda
+++ b/extend/Dockerfile.cuda
@@ -1,25 +1,68 @@
 ARG BASE=rocker/cuda
+
+# Stage 1: build GDAL's Arrow/Parquet drivers as plugins.
+#
+# Ubuntu ships GDAL without these drivers -- libarrow-dev is not in GDAL's
+# Build-Depends, so cmake never finds Arrow and the code is simply absent from
+# libgdal. Upstream builds them as dlopen'd plugins precisely so they can be
+# added without touching libgdal, which is what we do here: compile the two
+# driver targets against the *distro's* GDAL and Arrow, keep the two .so files,
+# throw the rest of the build away.
+#
+# Building from $BASE rather than a bare ubuntu image is deliberate: it
+# guarantees the same apt sources, so the plugin is compiled against exactly the
+# libgdal and libarrow the final image will load it into. Plugin and host must
+# agree on both ABIs.
+FROM $BASE AS plugin-builder
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build ca-certificates curl \
+    libgdal-dev libarrow-dev libparquet-dev libarrow-dataset-dev libarrow-acero-dev
+WORKDIR /src
+RUN GDAL_VER="$(gdal-config --version)" && \
+    echo "Building Arrow/Parquet plugins for GDAL ${GDAL_VER}" && \
+    curl -sL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VER}/gdal-${GDAL_VER}.tar.gz" \
+      | tar xz && \
+    mv "gdal-${GDAL_VER}" gdal && \
+    cmake -S gdal -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_APPS=OFF -DBUILD_TESTING=OFF \
+      -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JAVA_BINDINGS=OFF -DBUILD_CSHARP_BINDINGS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DGDAL_USE_ARROW=ON -DGDAL_USE_PARQUET=ON -DGDAL_USE_ARROWDATASET=ON \
+      -DOGR_ENABLE_DRIVER_ARROW=ON -DOGR_ENABLE_DRIVER_ARROW_PLUGIN=ON \
+      -DOGR_ENABLE_DRIVER_PARQUET=ON -DOGR_ENABLE_DRIVER_PARQUET_PLUGIN=ON && \
+    cmake --build build --target ogr_Parquet ogr_Arrow -j"$(nproc)" && \
+    mkdir /plugins && cp build/gdalplugins/ogr_Parquet.so build/gdalplugins/ogr_Arrow.so /plugins/
+
+# Stage 2: the spatial image
 FROM $BASE
 
 USER root
 
-# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12), so there is no
-# multi-stage copy from the OSGeo image any more. That copy was dead weight: r2u
-# installs prebuilt r-cran-sf/terra linked against the distro libgdal, and the
-# Python wheels vendor their own GDAL, so nothing ever loaded the copied library.
-# Note Ubuntu does not build GDAL's Arrow/Parquet drivers; use the arrow/geoarrow
-# R packages or pyarrow/geopandas for GeoParquet.
-# libgdal-dev supplies gdal-config, needed by any Python spatial package that
-# has no wheel for the base image's Python and must build from its sdist
-# (fiona, currently). Those then link this same system GDAL.
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
+# packages are needed because the Python spatial packages below are built from
+# source against them.
 # Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
 # r-cran-* binaries, and with the lists emptied it cannot find them and silently
 # falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdal-bin \
-    libgdal-dev
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    proj-bin \
+    libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
+
+COPY --from=plugin-builder /plugins /tmp/plugins
+RUN PLUGDIR="/usr/lib/$(gcc -print-multiarch)/gdalplugins" && \
+    mkdir -p "$PLUGDIR" && mv /tmp/plugins/*.so "$PLUGDIR/" && rmdir /tmp/plugins && \
+    ogrinfo --formats | grep -q '^  Parquet ' || \
+      { echo "ERROR: Parquet driver did not load -- plugin/libgdal ABI mismatch?"; exit 1; }
 
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
+# pyproj's sdist looks for the proj executable and headers under PROJ_DIR
+ENV PROJ_DIR=/usr
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash
@@ -31,8 +74,16 @@ COPY install.r install.r
 RUN Rscript install.r && \
     rm -rf /tmp/* /var/tmp/*
 
+# Build the GEOS/PROJ/GDAL-linked packages from source against the system
+# libraries rather than taking wheels that vendor their own copies. Otherwise
+# the image carries several GDALs, which one you get depends on whether a wheel
+# happens to exist for this Python, and the vendored copies cannot see the
+# Parquet plugin installed above.
+ENV SPATIAL_NO_BINARY="--no-binary rasterio --no-binary fiona --no-binary pyogrio \
+--no-binary pyproj --no-binary shapely"
+
 # Pre-install core spatial packages to avoid complex resolution backtracking
-RUN uv pip install --verbose --no-cache-dir \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} \
     numpy \
     "cligj>=0.5" \
     "click-plugins>=1.0" \
@@ -43,5 +94,13 @@ RUN uv pip install --verbose --no-cache-dir \
 
 ## Python extensions
 COPY requirements.cuda.txt requirements.txt
-RUN uv pip install --verbose --no-cache-dir -r requirements.txt && \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} -r requirements.txt && \
     rm requirements.txt
+
+# Fail the build if anything silently reverted to a vendored GDAL
+RUN python -c "\
+import rasterio, fiona, pyogrio, subprocess, sys;\
+sysgdal = subprocess.run(['gdal-config','--version'], capture_output=True, text=True).stdout.strip();\
+seen = {'rasterio': rasterio.__gdal_version__, 'fiona': fiona.__gdal_version__, 'pyogrio': pyogrio.__gdal_version_string__};\
+bad = {k: v for k, v in seen.items() if v != sysgdal};\
+sys.exit('ERROR: not linked against system GDAL %s: %s' % (sysgdal, bad)) if bad else print('all Python bindings on system GDAL', sysgdal)"

--- a/extend/Dockerfile.cuda
+++ b/extend/Dockerfile.cuda
@@ -1,92 +1,25 @@
 ARG BASE=rocker/cuda
-ARG GDAL_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.10.3
-
-# Stage 1: Get GDAL binaries with Arrow/Parquet support from official image
-FROM ${GDAL_IMAGE} AS gdal-builder
-# The upstream GDAL image ships an Apache Arrow apt source whose signing key has
-# rotated, breaking `apt-get update`. Arrow libs are already baked into the image
-# and we only need libgeos-dev (from Ubuntu's own repos), so drop the stale source.
-RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources && \
-    apt-get update && apt-get install -y libgeos-dev
-
-# Detect architecture and set allow-list path
-RUN export ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        export ARCH_TRIPLET="x86_64-linux-gnu"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        export ARCH_TRIPLET="aarch64-linux-gnu"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    mkdir -p /opt/rootfs/usr/bin && \
-    mkdir -p /opt/rootfs/usr/include && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET} && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/cmake && \
-    mkdir -p /opt/rootfs/usr/local && \
-    cp -r /usr/local/* /opt/rootfs/usr/local/ && \
-    \
-    cp /usr/bin/gdal-config /opt/rootfs/usr/bin/ && \
-    cp /usr/bin/geos-config /opt/rootfs/usr/bin/ && \
-    cp -r /usr/include/* /opt/rootfs/usr/include/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgdal* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libproj* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgeos* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libarrow* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libparquet* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libjxl* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libQB3* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp -r /usr/lib/${ARCH_TRIPLET}/cmake /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    \
-    # Copy pkgconfig files
-    cp /usr/lib/${ARCH_TRIPLET}/pkgconfig/gdal.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/ && \
-    cp /usr/local/lib/pkgconfig/proj.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/
-
-# Stage 2: Build our spatial image
-FROM $BASE 
+FROM $BASE
 
 USER root
 
-# Copy all staged files from the builder
-COPY --from=gdal-builder /opt/rootfs /
-
-# Set up environment variables
-# We use a trick to dynamically set PKG_CONFIG_PATH based on available directories
-RUN if [ -d "/usr/lib/aarch64-linux-gnu" ]; then \
-        echo "Detected aarch64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    else \
-        echo "Detected x86_64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    fi
-
-ENV PATH="/usr/local/bin:$PATH"
-ENV GDAL_CONFIG=/usr/bin/gdal-config
-# Set a default for build time, though /etc/environment handles runtime
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
-
-# Install runtime dependencies for GDAL
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12), so there is no
+# multi-stage copy from the OSGeo image any more. That copy was dead weight: r2u
+# installs prebuilt r-cran-sf/terra linked against the distro libgdal, and the
+# Python wheels vendor their own GDAL, so nothing ever loaded the copied library.
+# Note Ubuntu does not build GDAL's Arrow/Parquet drivers; use the arrow/geoarrow
+# R packages or pyarrow/geopandas for GeoParquet.
+# libgdal-dev supplies gdal-config, needed by any Python spatial package that
+# has no wheel for the base image's Python and must build from its sdist
+# (fiona, currently). Those then link this same system GDAL.
+# Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
+# r-cran-* binaries, and with the lists emptied it cannot find them and silently
+# falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libopenjp2-7 libcairo2 \
-    libpng16-16t64 libjpeg-turbo8 libgif7 liblzma5 \
-    libxml2 libexpat1 libxerces-c3.2 \
-    libnetcdf-c++4-1 libpoppler134 libspatialite8 \
-    libhdf4-0-alt libhdf5-103-1t64 libfreexl1 unixodbc libwebp7 \
-    liblcms2-2 libpcre3 libfyba0 \
-    libkmlbase1 libkmldom1 libkmlengine1 \
-    libmysqlclient21 libcfitsio10t64 libzstd1 libpq5 \
-    libarmadillo12 libopenexr-3-1-30 libheif1 libavif16 \
-    libdeflate0 libblosc1 liblz4-1 libbrotli1 \
-    libarchive13t64 libcrypto++8t64 libjxl0.7 liblerc4 \
-    libsz2 librasterlite2-1 \
-    && ldconfig \
-    && rm -rf /var/lib/apt/lists/*
+    gdal-bin \
+    libgdal-dev
 
-
-# GDAL environment
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
-ENV GDAL_DATA=/usr/local/share/gdal
-ENV PROJ_DATA=/usr/local/share/proj
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash

--- a/extend/README.md
+++ b/extend/README.md
@@ -12,15 +12,40 @@ This folder contains the spatial extension images (`rocker/cuda-spatial` and `ro
 ### GDAL
 
 These images use the GDAL that ships with the Ubuntu base (GDAL 3.12 on Ubuntu
-26.04). R's `sf`/`terra` come from r2u as prebuilt binaries linked against that
-same system library, so there is a single, consistent GDAL throughout.
+26.04). Everything binds that one library:
 
-Ubuntu does not enable GDAL's Arrow/Parquet drivers, so `.parquet` is not
-readable through `ogr2ogr`/`st_read()`. For GeoParquet use the `arrow` and
-`geoarrow` R packages, or `geopandas`/`pyarrow` in Python.
+- R's `sf`/`terra` come from r2u as prebuilt binaries linked against it
+- the Python packages that wrap GEOS/PROJ/GDAL (`rasterio`, `fiona`, `pyogrio`,
+  `pyproj`, `shapely`) are built from source against it, rather than taking
+  wheels that vendor their own copies
+- `gdal-bin` provides `ogrinfo`/`ogr2ogr` against the same library
 
-Note that the Python geospatial wheels (`rasterio`, `fiona`, `pyogrio`) each
-vendor their own copy of GDAL and do not use the system library.
+The build fails if any Python binding reports a GDAL version other than
+`gdal-config --version`, so a wheel silently reintroducing a second GDAL is a
+build error rather than a surprise at runtime.
+
+### Arrow/Parquet
+
+Ubuntu does not enable GDAL's Arrow/Parquet drivers -- `libarrow-dev` is not in
+GDAL's `Build-Depends`, and no Ubuntu package ships the drivers separately.
+Upstream builds them as plugins, so these images compile just those two drivers
+from the matching GDAL source against the distro's libgdal and libarrow, and
+install them into `gdalplugins/`.
+
+The result is `(Geo)Parquet` and `(Geo)Arrow` read/write available everywhere
+that binds GDAL -- `sf`, `terra`, `ogr2ogr`, `pyogrio`, `fiona`, `geopandas` --
+including remote files over `/vsis3` and `/vsicurl`:
+
+```r
+st_write(nc, "out.parquet", driver = "Parquet")
+st_read("/vsis3/bucket/data.parquet")
+```
+
+Note `sf` does not map the `.parquet` extension to a driver, so `driver =
+"Parquet"` is required when writing. Reading auto-detects.
+
+The `arrow` and `geoarrow` R packages are also installed, with S3 and GCS
+support, for working with (Geo)Parquet outside GDAL.
 
 ### Included Packages
 

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,15 +9,18 @@ This folder contains the spatial extension images (`rocker/cuda-spatial` and `ro
 
 ## Key Features
 
-### GDAL with Arrow/Parquet Support
+### GDAL
 
-These images use a **multi-stage build** to include GDAL 3.10 with full Arrow/Parquet/GeoParquet support:
+These images use the GDAL that ships with the Ubuntu base (GDAL 3.12 on Ubuntu
+26.04). R's `sf`/`terra` come from r2u as prebuilt binaries linked against that
+same system library, so there is a single, consistent GDAL throughout.
 
-- **GeoParquet** - Read/write GeoParquet files directly with GDAL
-- **Arrow** - Apache Arrow integration for high-performance data exchange
-- **Parquet** - Native Parquet format support in GDAL
+Ubuntu does not enable GDAL's Arrow/Parquet drivers, so `.parquet` is not
+readable through `ogr2ogr`/`st_read()`. For GeoParquet use the `arrow` and
+`geoarrow` R packages, or `geopandas`/`pyarrow` in Python.
 
-The GDAL libraries are copied from the official `ghcr.io/osgeo/gdal:ubuntu-full` image, which is built with all drivers enabled including Arrow/Parquet support that Ubuntu's default GDAL package lacks.
+Note that the Python geospatial wheels (`rasterio`, `fiona`, `pyogrio`) each
+vendor their own copy of GDAL and do not use the system library.
 
 ### Included Packages
 

--- a/extend/install.r
+++ b/extend/install.r
@@ -5,6 +5,8 @@ install.packages(c(
 'rstac',
 'terra',
 'mapgl',
-'gifski'))
+'gifski',
+'arrow',
+'geoarrow'))
 
 

--- a/extend/requirements-cpu.txt
+++ b/extend/requirements-cpu.txt
@@ -1,5 +1,5 @@
 # Geospatial and data science extensions for CPU image
-# Note: GDAL with Arrow/Parquet support is installed from system via multi-stage build
+# Note: GDAL comes from the Ubuntu base; see extend/README.md
 
 # Cloud and storage
 boto3

--- a/extend/requirements.cuda.txt
+++ b/extend/requirements.cuda.txt
@@ -1,5 +1,5 @@
 # Geospatial and data science extensions for RAPIDS GPU image
-# Note: GDAL with Arrow/Parquet support is installed from system via multi-stage build
+# Note: GDAL comes from the Ubuntu base; see extend/README.md
 
 # Cloud and storage
 boto3

--- a/install_r.sh
+++ b/install_r.sh
@@ -20,7 +20,6 @@ apt-get update
 wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \
     | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
 echo "deb [arch=${ARCH}] https://cloud.r-project.org/bin/linux/ubuntu ${UBUNTU_CODENAME}-cran40/" > /etc/apt/sources.list.d/cran_r.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 67C2D66C4B1D4339 51716619E084DAB9
 apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends r-base r-base-dev r-recommended
 

--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -35,11 +35,11 @@ fi
 
 # RStudio Server .deb builds are only published for a limited set of Ubuntu
 # codenames, so map the ones we run on to the nearest available build:
-#   - noble (24.04) has no dedicated server build yet -> use jammy
+#   - resolute (26.04) and noble (24.04) have no dedicated server build -> use jammy
 #   - focal (20.04) -> use jammy
 #   - arm64 is only published for jammy
 case "$UBUNTU_CODENAME" in
-    noble | focal) UBUNTU_CODENAME="jammy" ;;
+    resolute | noble | focal) UBUNTU_CODENAME="jammy" ;;
 esac
 if [ "$ARCH" = "arm64" ] && [ "$UBUNTU_CODENAME" != "jammy" ]; then
     UBUNTU_CODENAME="jammy"

--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -33,17 +33,13 @@ if [ "$RSTUDIO_VERSION" = "latest" ]; then
     RSTUDIO_VERSION="stable"
 fi
 
-# RStudio Server .deb builds are only published for a limited set of Ubuntu
-# codenames, so map the ones we run on to the nearest available build:
-#   - resolute (26.04) and noble (24.04) have no dedicated server build -> use jammy
-#   - focal (20.04) -> use jammy
-#   - arm64 is only published for jammy
-case "$UBUNTU_CODENAME" in
-    resolute | noble | focal) UBUNTU_CODENAME="jammy" ;;
-esac
-if [ "$ARCH" = "arm64" ] && [ "$UBUNTU_CODENAME" != "jammy" ]; then
-    UBUNTU_CODENAME="jammy"
-fi
+# jammy is the only Ubuntu server path Posit publishes, for both arches. That
+# deb is genuinely built on jammy (max required symbols GLIBC_2.34 /
+# GLIBCXX_3.4.29) and its Depends are codename-agnostic, so it is the manylinux
+# pattern -- build old, run anywhere forward -- rather than a stale URL. Take it
+# unconditionally: allow-listing the codenames we know about means every future
+# release 404s until someone adds it. See rocker-org/ml#50.
+UBUNTU_CODENAME="jammy"
 
 # Resolve the "stable" keyword to a concrete version number.
 #

--- a/requirements.cuda.txt
+++ b/requirements.cuda.txt
@@ -1,7 +1,9 @@
-# RAPIDS packages with CUDA 13 support (25.12 stable release)
+# RAPIDS packages with CUDA 13 support
 # cudf includes built-in Polars interoperability (df.to_polars() / cudf.from_polars())
 --extra-index-url=https://pypi.nvidia.com
-cudf-cu13==25.12.*
+# 26.x ships cp311-abi3 wheels (usable on the base image's Python 3.14);
+# the 25.12 series was cp313-only and cannot install here.
+cudf-cu13>=26.4
 
 
 # PyTorch with CUDA 13 (from PyTorch index)

--- a/requirements.cuda.txt
+++ b/requirements.cuda.txt
@@ -8,7 +8,12 @@ cudf-cu13>=26.4
 
 # PyTorch with CUDA 13 (from PyTorch index)
 --extra-index-url=https://download.pytorch.org/whl/cu130
-torch
+# The floor is load-bearing, not a version preference. Resolving the full file
+# without it, pip backtracks to torch 2.9.1 -- a CUDA 12.8 build -- even though
+# a consistent CUDA 13 solution exists. That pulls a second, complete CUDA 12
+# userspace (nvidia-*-cu12) in alongside RAPIDS' CUDA 13 one, several GB of
+# duplication in an image whose whole point is a single CUDA stack.
+torch>=2.13
 torchvision
 torchaudio
 


### PR DESCRIPTION
Moves all four images to Ubuntu 26.04 and deletes the multi-stage GDAL copy from the spatial extension. Closes #50, closes #51.

## Why

The spatial images copied a whole GDAL out of `ghcr.io/osgeo/gdal`, but **nothing ever linked it**. Measured in the current `latest`:

| consumer | GDAL actually loaded | source |
|---|---|---|
| R `sf` / `terra` | 3.8.4 | Ubuntu apt, pulled by bspm/r2u |
| `rasterio` | 3.9.3 | vendored in wheel |
| `fiona` | 3.9.2 | vendored in wheel |
| copied `libgdal.so.38` | 3.12.4 | **nothing links to it** |

r2u installs prebuilt `r-cran-sf`/`terra` linked against the distro `libgdal`, and the Python wheels vendor their own, so `gdal-config` pointing at the copied library was never consulted. The image shipped two GDALs, no `gdalinfo`/`ogr2ogr` at all, and no working Parquet driver despite the README advertising one (`st_write(driver="Parquet")` → `Driver not available`).

Bumping the pin alone does not fix this, and GDAL 3.13+ cannot be copied anyway: it is built on Ubuntu 26.04 and needs `GLIBC_2.43` against the base's 2.39.

## What changes

Ubuntu 26.04 ships **GDAL 3.12.2**, and both r2u and CRAN-apt publish for `resolute`, so the distro GDAL is now current enough to use directly.

- base images → `ubuntu:26.04` / `nvidia/cuda:13.3.1-runtime-ubuntu26.04`
- `extend/`: drop the builder stage, the arch-triplet `cp` block, and the 41-line soname list (#51); install `gdal-bin` + `libgdal-dev` instead
- `install_rstudio.sh`: take the jammy build unconditionally (#50)
- `install_r.sh`: drop `apt-key` (removed in 26.04; redundant, both keys already in `trusted.gpg.d`)
- `requirements.cuda.txt`: `cudf-cu13` 25.12 is cp313-only and cannot install on 26.04's Python 3.14; 26.x ships `cp311-abi3`
- `extend/install.r`: add `arrow` + `geoarrow`, the GeoParquet path now that GDAL's Parquet driver is unavailable
- both base Dockerfiles now `COPY` their scripts instead of curling them from `master` (see below)

## Results

All four images built and tested locally on amd64.

```
sf GDAL 3.12.2 | GEOS 3.14.1 | PROJ 9.7.1      (was 3.8.4 / 3.12.1 / 9.4.0)
rasterio gdal 3.12.2 | fiona gdal 3.12.2       (were 3.9.3 / 3.9.2, vendored)
ogrinfo: GDAL 3.12.2                            (was absent)
R packages: 22 r2u binaries, 0 source builds
R GeoParquet roundtrip: 100 features (arrow + geoarrow)
py GeoParquet roundtrip: ok (geopandas/pyarrow)
cudf 26.08.00 imports cleanly
```

`ml-spatial` shrinks 10.1 GB → 9.36 GB, from removing the duplicate GDAL.

A side benefit: with `libgdal-dev` present, the Python packages lacking cp314 wheels build from sdist and link the *system* GDAL, so `rasterio` and `fiona` are on 3.12.2 too. Only `pyogrio` still vendors its own.

## Arrow/Parquet

Ubuntu ships GDAL without these drivers. It is not a component or architecture
constraint -- `gdal-bin`, `libgdal38`, `libarrow-dev` and `libparquet2300` are all
universe, all `arch=any` -- it is that `libarrow-dev` is not in GDAL's
`Build-Depends`, so cmake never finds Arrow and the code is absent from `libgdal`.
Coupling GDAL, a transition hub, to a library whose soname bumps quarterly is the
tradeoff being avoided. Upstream's answer is to build the drivers as dlopen'd
plugins, which is how Alpine and conda-forge ship them; Debian just hasn't
packaged that binary.

So these images build the two driver targets from the matching GDAL source
against the distro's libgdal and libarrow, and install them into `gdalplugins/`.
The builder stage runs `FROM $BASE`, so the plugin is compiled against exactly the
libraries it gets loaded into, and the build asserts the driver actually loads
rather than shipping a silently inert `.so`.

## One GDAL everywhere

The Python packages wrapping GEOS/PROJ/GDAL (`rasterio`, `fiona`, `pyogrio`,
`pyproj`, `shapely`) are now built from source against the system libraries
instead of taking wheels that vendor their own copies.

This was previously nondeterministic -- whether a package linked the system GDAL
depended on whether a wheel happened to exist for the image's Python:

```
before:  ml-spatial   rasterio 1.4.3  gdal 3.12.2  system-linked
         cuda-spatial rasterio 1.5.1  gdal 3.12.4  vendored
after:   both         rasterio        gdal 3.12.2  system-linked
```

It also matters for the plugin: a vendored GDAL cannot see drivers installed in
the system `gdalplugins/`, and `pyogrio` is geopandas' default engine, so leaving
the wheels in place would have given Parquet to R and not to Python.

The build fails if any binding reports a GDAL version other than
`gdal-config --version`.

### Verified

```
ogrinfo --formats            → Parquet (rw+uv), Arrow (rw+v)
sf     st_write(driver="Parquet") + st_read   → 100 features, epsg 4267
terra  writeVector(filetype="Parquet")        → 12 features
pyogrio / fiona                                → Parquet rw
sf      /vsis3 Overture GeoParquet             → 3 features, MULTIPOLYGON
pyogrio /vsis3 Overture GeoParquet             → 3 features, MultiPolygon
```

`sf` does not map the `.parquet` extension to a driver, so `driver = "Parquet"`
is needed when writing; reading auto-detects.

The `arrow` and `geoarrow` R packages are also installed as an out-of-GDAL path,
with `s3` and `gcs` enabled (verified against public S3 and GCS buckets).

## Note on the curl-from-master change

`Dockerfile.cuda` fetched `install_r.sh`, `Rprofile` and `install_utilities.sh` from `master` at build time, so changes to those scripts could never be exercised on a branch or in a PR — the build silently used the merged version. It surfaced here as the CUDA build failing on an `apt-key` call this branch had already removed. Both base Dockerfiles now COPY from the build context, matching how `install_rstudio.sh` and `set_renviron.sh` were already handled.

## Still to verify

- **GPU runtime**: cudf 26.8 against the CUDA 13.3 runtime needs a GPU. Build and import are clean; `python -c "import cudf; print(cudf.DataFrame({'a':[1,2]}).sum())"` would settle it.
- **arm64**: only amd64 was built locally.
- **RStudio**: `rstudio-server verify-installation` returns 1 with no output — but it does so on the current 24.04 images too, so this is unchanged behavior, not a regression. Shared libraries all resolve. A real check needs the jupyter-rsession-proxy path (cf. #41).

## Unrelated pre-existing issue spotted

`rocker/cuda` resolves **torch 2.9.1+cu128** — a CUDA 12.8 build inside a CUDA 13 runtime image — despite the `cu130` extra index. Not caused by this branch: master's requirements on Python 3.12 resolve to 2.9.1 as well, while requesting `torch` alone from that index gives 2.13.0+cu130. Probably worth its own issue.
