### PR TITLE
ci: stop non-master builds from publishing tags

### DIFF
--- a/.github/workflows/build-cuda-spatial.yml
+++ b/.github/workflows/build-cuda-spatial.yml
@@ -112,6 +112,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
   push:
+    branches: [master, main]
     paths:
       - Dockerfile.cuda
       - install*.sh
@@ -108,6 +109,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-ml-spatial.yml
+++ b/.github/workflows/build-ml-spatial.yml
@@ -112,6 +112,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
   push:
+    branches: [master, main]
     paths:
       - Dockerfile.cpu
       - install*.sh
@@ -110,6 +111,10 @@ jobs:
 
   merge:
     name: Merge manifests and push tags
+    # Pull requests build (to validate the Dockerfile) but must never publish
+    # tags: this job is what writes :latest, and a PR run doing so overwrites
+    # the released images with unmerged code.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     permissions: write-all


### PR DESCRIPTION
First of three; the other two depend on this landing first.

Two independent holes let unmerged code reach the published tags.

**1. The base workflows had no branch filter.** `build-ml.yml` and `build-cuda.yml` triggered on `push:` to *any* branch, and the merge job tags `latest` unconditionally.

**2. `pull_request` runs reach the tag-publishing job.** All four workflows build on PRs, and nothing stops the merge job from writing tags.

These are not hypothetical — both fired while preparing the 26.04 work:

```
01:49  push         <topic branch>  Build ML (CPU) Base    → success   ← published :latest
01:49  push         <topic branch>  Build CUDA (GPU) Base  → success   ← published :latest
02:00  workflow_run master          Build ML-Spatial       → FAILURE
02:10  workflow_run master          Build CUDA-Spatial     → FAILURE
```

`rocker/ml:latest` and `rocker/cuda:latest` were replaced by a topic branch's build, the version-labelled tags (`cuda13.0-py3.12-rapids25.12`) began describing an image that didn't match, and master's spatial builds then failed because the `workflow_run` chain rebuilt them against the swapped base. All four images have since been restored by re-running the master workflows.

## Fix

- `branches: [master, main]` on the base workflows' `push:` trigger.
- `if: github.event_name != 'pull_request'` on the merge job in all four.

PRs still build both architectures, so Dockerfiles are still validated — they just no longer release the result. Verified on a live PR run: `Merge manifests and push tags: skipped`.

## Known residue

PR builds still push *untagged* digests to both registries (that's how `push-by-digest` works). Those are unreferenced and garbage-collectable, and stopping them would mean restructuring the build job, so I left it. Only the tagging is guarded, which is the part that caused the damage.
