### PR TITLE
Move the base images to Ubuntu 26.04

### DIFF
--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -20,7 +20,9 @@ on:
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/cuda
   DOCKER_IMAGE: rocker/cuda
-  TAGS: latest cuda13.0-py3.12-rapids25.12 cuda13.0-py3.12 cuda13.0
+  # No rapids<version> tag: cudf now floats (>=26.4) rather than being pinned to a
+  # release series, so such a tag would go stale on the next rebuild.
+  TAGS: latest cuda13.3-py3.14 cuda13.3
 
 jobs:
   build:

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -19,7 +19,7 @@ on:
 env:
   GHCR_IMAGE: ghcr.io/rocker-org/ml
   DOCKER_IMAGE: rocker/ml
-  TAGS: latest py3.12
+  TAGS: latest py3.14
 
 jobs:
   build:

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,5 @@
 # CPU-only pip-based image
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV SHELL=/bin/bash
 # Don't buffer Python stdout/stderr output
@@ -25,11 +25,11 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 USER root
 
-# Ubuntu 24.04 base has ubuntu user/group at UID/GID 1000, rename to jovyan
+# Ubuntu 26.04 base has ubuntu user/group at UID/GID 1000, rename to jovyan
 RUN groupmod -n ${NB_USER} ubuntu && \
     usermod -l ${NB_USER} -d /home/${NB_USER} -m ubuntu
 
-# Install Python 3.12 (default in Ubuntu 24.04) and system dependencies
+# Install Python 3.14 (default in Ubuntu 26.04) and system dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \
@@ -57,7 +57,8 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # apt utilities, code-server setup
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_utilities.sh | bash
+COPY install_utilities.sh install_utilities.sh
+RUN bash install_utilities.sh
 
 ## Grant user sudoer privileges
 RUN apt-get update && apt-get -y install sudo && \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,5 +1,5 @@
 # Use CUDA 13 runtime image (includes NVRTC for Numba, lighter than devel)
-FROM nvidia/cuda:13.0.0-runtime-ubuntu24.04
+FROM nvidia/cuda:13.3.1-runtime-ubuntu26.04
 
 ENV SHELL=/bin/bash
 # Don't buffer Python stdout/stderr output
@@ -33,7 +33,7 @@ USER root
 RUN groupmod -n ${NB_USER} ubuntu && \
     usermod -l ${NB_USER} -d /home/${NB_USER} -m ubuntu
 
-# Install Python 3.12 (default in Ubuntu 24.04) and system dependencies
+# Install Python 3.14 (default in Ubuntu 26.04) and system dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \
@@ -63,14 +63,16 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh && \
     rm -rf .cache /tmp/* /var/tmp/* 
 
 # apt utilities, code-server setup
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_utilities.sh | bash
+COPY install_utilities.sh install_utilities.sh
+RUN bash install_utilities.sh
 
 ## Grant user sudoer privileges
 RUN adduser "$NB_USER" sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 # Install R
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/install_r.sh | bash
-RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/Rprofile -o /usr/lib/R/etc/Rprofile.site
+COPY install_r.sh install_r.sh
+RUN bash install_r.sh
+COPY Rprofile /usr/lib/R/etc/Rprofile.site
 
 # RStudio
 COPY install_rstudio.sh install_rstudio.sh

--- a/install_r.sh
+++ b/install_r.sh
@@ -20,7 +20,6 @@ apt-get update
 wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \
     | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
 echo "deb [arch=${ARCH}] https://cloud.r-project.org/bin/linux/ubuntu ${UBUNTU_CODENAME}-cran40/" > /etc/apt/sources.list.d/cran_r.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 67C2D66C4B1D4339 51716619E084DAB9
 apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends r-base r-base-dev r-recommended
 

--- a/install_rstudio.sh
+++ b/install_rstudio.sh
@@ -33,17 +33,13 @@ if [ "$RSTUDIO_VERSION" = "latest" ]; then
     RSTUDIO_VERSION="stable"
 fi
 
-# RStudio Server .deb builds are only published for a limited set of Ubuntu
-# codenames, so map the ones we run on to the nearest available build:
-#   - noble (24.04) has no dedicated server build yet -> use jammy
-#   - focal (20.04) -> use jammy
-#   - arm64 is only published for jammy
-case "$UBUNTU_CODENAME" in
-    noble | focal) UBUNTU_CODENAME="jammy" ;;
-esac
-if [ "$ARCH" = "arm64" ] && [ "$UBUNTU_CODENAME" != "jammy" ]; then
-    UBUNTU_CODENAME="jammy"
-fi
+# jammy is the only Ubuntu server path Posit publishes, for both arches. That
+# deb is genuinely built on jammy (max required symbols GLIBC_2.34 /
+# GLIBCXX_3.4.29) and its Depends are codename-agnostic, so it is the manylinux
+# pattern -- build old, run anywhere forward -- rather than a stale URL. Take it
+# unconditionally: allow-listing the codenames we know about means every future
+# release 404s until someone adds it. See rocker-org/ml#50.
+UBUNTU_CODENAME="jammy"
 
 # Resolve the "stable" keyword to a concrete version number.
 #

--- a/requirements.cuda.txt
+++ b/requirements.cuda.txt
@@ -1,12 +1,19 @@
-# RAPIDS packages with CUDA 13 support (25.12 stable release)
+# RAPIDS packages with CUDA 13 support
 # cudf includes built-in Polars interoperability (df.to_polars() / cudf.from_polars())
 --extra-index-url=https://pypi.nvidia.com
-cudf-cu13==25.12.*
+# 26.x ships cp311-abi3 wheels (usable on the base image's Python 3.14);
+# the 25.12 series was cp313-only and cannot install here.
+cudf-cu13>=26.4
 
 
 # PyTorch with CUDA 13 (from PyTorch index)
 --extra-index-url=https://download.pytorch.org/whl/cu130
-torch
+# The floor is load-bearing, not a version preference. Resolving the full file
+# without it, pip backtracks to torch 2.9.1 -- a CUDA 12.8 build -- even though
+# a consistent CUDA 13 solution exists. That pulls a second, complete CUDA 12
+# userspace (nvidia-*-cu12) in alongside RAPIDS' CUDA 13 one, several GB of
+# duplication in an image whose whole point is a single CUDA stack.
+torch>=2.13
 torchvision
 torchaudio
 


### PR DESCRIPTION
Second of three. Merge after #53 (so this branch's push cannot publish from a topic branch), before #54.

Ubuntu 26.04 ships **GDAL 3.12, Python 3.14, R 4.6**, and both r2u and CRAN-apt publish for `resolute`, so the whole stack builds from binaries again. Readiness checked before starting:

| dependency | 26.04 status |
|---|---|
| r2u `resolute` | published (`r-cran-sf` built against `libgdal38`) |
| CRAN-apt `resolute-cran40` | published |
| `nvidia/cuda:*-ubuntu26.04` | published (13.3.x) |
| RStudio Server | jammy only — but that is already true on noble |

## Four things break on the way

- **`apt-key` was removed in 26.04**, killing `install_r.sh`. The call was redundant: both keys are already installed under `trusted.gpg.d`.
- **RStudio publishes no `resolute` build**, so take the jammy one unconditionally rather than allow-listing codenames (closes #50; folded in because the bump needs it).
- **`cudf-cu13` 25.12 is cp313-only** and cannot install on Python 3.14. The 26.x series ships `cp311-abi3` wheels that can.
- **torch needs a floor.** Resolving the full requirements file without one, pip backtracks to torch 2.9.1 — a CUDA 12.8 build — even though a consistent CUDA 13 solution exists. That pulled a second complete CUDA 12 userspace in alongside RAPIDS' CUDA 13:

```
before:  torch 2.9.1+cu128   nvidia-cublas 13.6.0.2 AND nvidia-cublas-cu12 12.8.4.1   (~15 dup packages)
after:   torch 2.13.0+cu130  single CUDA 13 stack, zero cu12 packages
```

This is not a torch/RAPIDS incompatibility — `torch torchvision torchaudio cudf-cu13` resolve together onto CUDA 13 fine. It is pip backtracking, and it predates 26.04 (master's requirements on Python 3.12 resolve the same way). A floor rather than a pin, so the no-pinning policy holds; the comment marks it load-bearing so it does not get tidied away later.

## Also: the CUDA image now builds from the checkout

`Dockerfile.cuda` fetched `install_r.sh`, `Rprofile` and `install_utilities.sh` from `master` over the network, so changes to those scripts could never be exercised on a branch or in a PR — the build silently used the merged version instead. That is exactly how the `apt-key` failure above stayed hidden until the base image changed. Both base Dockerfiles now COPY from the build context, matching how `install_rstudio.sh` and `set_renviron.sh` were already handled.

Version tags are corrected to match the images (`py3.14`, `cuda13.3`). The `rapids<version>` tag is dropped, since cudf now floats and such a tag would go stale on the next rebuild.

## Tested

Both base images built locally on amd64:

```
Ubuntu 26.04 LTS | Python 3.14.4 | R 4.6.1
torch 2.13.0+cu130 (CUDA 13.0) | cudf 26.08.00 | zero cu12 packages
CUDA runtime libs load; rstudio-server installs (jammy deb, all sonames resolve)
cuda 20.0GB -> 16.1GB
```

**Not verified:** GPU execution (needs a device — `import cudf; cudf.DataFrame(...).sum()`), and arm64.
