### PR TITLE
Drop the multi-stage GDAL copy; add the Arrow/Parquet drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ This repository contains images for machine learning and GPU-based computation i
 - **`rocker/ml-spatial`** - Extends `rocker/ml` with geospatial packages
   - Tags: `latest`
 
-The spatial images include **GDAL 3.10 with Arrow/Parquet support** via multi-stage build from the official OSGeo GDAL image. This enables:
-- **GeoParquet** format support for efficient geospatial data storage
-- **Apache Arrow** integration for high-performance data exchange
-- Full suite of geospatial packages: GeoPandas, Rasterio, Xarray, PySTAC, etc.
+The spatial images use the GDAL provided by the Ubuntu base (**GDAL 3.12** on
+Ubuntu 26.04). R's `sf`/`terra` and the Python bindings (`rasterio`, `fiona`,
+`pyogrio`, ...) all link that single library, and GDAL's **Arrow/Parquet**
+drivers -- which Ubuntu does not ship -- are compiled as plugins against it. So
+`(Geo)Parquet` read/write works from `sf`, `terra`, `ogr2ogr` and `geopandas`
+alike, including remote files over `/vsis3` and `/vsicurl`. They also add a full
+suite of geospatial packages: GeoPandas, Rasterio, Xarray, PySTAC, etc.
 
 See [extend/README.md](extend/README.md) for details on the spatial image build.
 

--- a/extend/Dockerfile.cpu
+++ b/extend/Dockerfile.cpu
@@ -1,91 +1,68 @@
 ARG BASE=rocker/ml
-ARG GDAL_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.10.3
 
-# Stage 1: Get GDAL binaries with Arrow/Parquet support from official image
-FROM ${GDAL_IMAGE} AS gdal-builder
-# The upstream GDAL image ships an Apache Arrow apt source whose signing key has
-# rotated, breaking `apt-get update`. Arrow libs are already baked into the image
-# and we only need libgeos-dev (from Ubuntu's own repos), so drop the stale source.
-RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources && \
-    apt-get update && apt-get install -y libgeos-dev
+# Stage 1: build GDAL's Arrow/Parquet drivers as plugins.
+#
+# Ubuntu ships GDAL without these drivers -- libarrow-dev is not in GDAL's
+# Build-Depends, so cmake never finds Arrow and the code is simply absent from
+# libgdal. Upstream builds them as dlopen'd plugins precisely so they can be
+# added without touching libgdal, which is what we do here: compile the two
+# driver targets against the *distro's* GDAL and Arrow, keep the two .so files,
+# throw the rest of the build away.
+#
+# Building from $BASE rather than a bare ubuntu image is deliberate: it
+# guarantees the same apt sources, so the plugin is compiled against exactly the
+# libgdal and libarrow the final image will load it into. Plugin and host must
+# agree on both ABIs.
+FROM $BASE AS plugin-builder
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build ca-certificates curl \
+    libgdal-dev libarrow-dev libparquet-dev libarrow-dataset-dev libarrow-acero-dev
+WORKDIR /src
+RUN GDAL_VER="$(gdal-config --version)" && \
+    echo "Building Arrow/Parquet plugins for GDAL ${GDAL_VER}" && \
+    curl -sL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VER}/gdal-${GDAL_VER}.tar.gz" \
+      | tar xz && \
+    mv "gdal-${GDAL_VER}" gdal && \
+    cmake -S gdal -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_APPS=OFF -DBUILD_TESTING=OFF \
+      -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JAVA_BINDINGS=OFF -DBUILD_CSHARP_BINDINGS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DGDAL_USE_ARROW=ON -DGDAL_USE_PARQUET=ON -DGDAL_USE_ARROWDATASET=ON \
+      -DOGR_ENABLE_DRIVER_ARROW=ON -DOGR_ENABLE_DRIVER_ARROW_PLUGIN=ON \
+      -DOGR_ENABLE_DRIVER_PARQUET=ON -DOGR_ENABLE_DRIVER_PARQUET_PLUGIN=ON && \
+    cmake --build build --target ogr_Parquet ogr_Arrow -j"$(nproc)" && \
+    mkdir /plugins && cp build/gdalplugins/ogr_Parquet.so build/gdalplugins/ogr_Arrow.so /plugins/
 
-# Detect architecture and set allow-list path
-RUN export ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        export ARCH_TRIPLET="x86_64-linux-gnu"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        export ARCH_TRIPLET="aarch64-linux-gnu"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    mkdir -p /opt/rootfs/usr/bin && \
-    mkdir -p /opt/rootfs/usr/include && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET} && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/cmake && \
-    mkdir -p /opt/rootfs/usr/local && \
-    cp -r /usr/local/* /opt/rootfs/usr/local/ && \
-    \
-    cp /usr/bin/gdal-config /opt/rootfs/usr/bin/ && \
-    cp /usr/bin/geos-config /opt/rootfs/usr/bin/ && \
-    cp -r /usr/include/* /opt/rootfs/usr/include/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgdal* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libproj* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgeos* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libarrow* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libparquet* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libjxl* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libQB3* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp -r /usr/lib/${ARCH_TRIPLET}/cmake /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    \
-    # Copy pkgconfig files
-    cp /usr/lib/${ARCH_TRIPLET}/pkgconfig/gdal.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/ && \
-    cp /usr/local/lib/pkgconfig/proj.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/
-
-# Stage 2: Build our spatial image
-FROM $BASE 
+# Stage 2: the spatial image
+FROM $BASE
 
 USER root
 
-# Copy all staged files from the builder
-COPY --from=gdal-builder /opt/rootfs /
-
-# Set up environment variables
-# We use a trick to dynamically set PKG_CONFIG_PATH based on available directories
-RUN if [ -d "/usr/lib/aarch64-linux-gnu" ]; then \
-        echo "Detected aarch64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    else \
-        echo "Detected x86_64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    fi
-
-ENV PATH="/usr/local/bin:$PATH"
-ENV GDAL_CONFIG=/usr/bin/gdal-config
-# Set a default for build time, though /etc/environment handles runtime
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
-
-# Install runtime dependencies for GDAL
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
+# packages are needed because the Python spatial packages below are built from
+# source against them.
+# Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
+# r-cran-* binaries, and with the lists emptied it cannot find them and silently
+# falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libopenjp2-7 libcairo2 \
-    libpng16-16t64 libjpeg-turbo8 libgif7 liblzma5 \
-    libxml2 libexpat1 libxerces-c3.2 \
-    libnetcdf-c++4-1 libpoppler134 libspatialite8 \
-    libhdf4-0-alt libhdf5-103-1t64 libfreexl1 unixodbc libwebp7 \
-    liblcms2-2 libpcre3 libfyba0 \
-    libkmlbase1 libkmldom1 libkmlengine1 \
-    libmysqlclient21 libcfitsio10t64 libzstd1 libpq5 \
-    libarmadillo12 libopenexr-3-1-30 libheif1 libavif16 \
-    libdeflate0 libblosc1 liblz4-1 libbrotli1 \
-    libarchive13t64 libcrypto++8t64 libjxl0.7 liblerc4 \
-    libsz2 librasterlite2-1 \
-    && ldconfig \
-    && rm -rf /var/lib/apt/lists/*
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    proj-bin \
+    libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
 
-# GDAL environment
+COPY --from=plugin-builder /plugins /tmp/plugins
+RUN PLUGDIR="/usr/lib/$(gcc -print-multiarch)/gdalplugins" && \
+    mkdir -p "$PLUGDIR" && mv /tmp/plugins/*.so "$PLUGDIR/" && rmdir /tmp/plugins && \
+    ogrinfo --formats | grep -q '^  Parquet ' || \
+      { echo "ERROR: Parquet driver did not load -- plugin/libgdal ABI mismatch?"; exit 1; }
+
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
-ENV GDAL_DATA=/usr/local/share/gdal
-ENV PROJ_DATA=/usr/local/share/proj
+# pyproj's sdist looks for the proj executable and headers under PROJ_DIR
+ENV PROJ_DIR=/usr
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash
@@ -96,8 +73,16 @@ USER ${NB_USER}
 COPY install.r install.r
 RUN Rscript install.r
 
+# Build the GEOS/PROJ/GDAL-linked packages from source against the system
+# libraries rather than taking wheels that vendor their own copies. Otherwise
+# the image carries several GDALs, which one you get depends on whether a wheel
+# happens to exist for this Python, and the vendored copies cannot see the
+# Parquet plugin installed above.
+ENV SPATIAL_NO_BINARY="--no-binary rasterio --no-binary fiona --no-binary pyogrio \
+--no-binary pyproj --no-binary shapely"
+
 # Pre-install core spatial packages to avoid complex resolution backtracking
-RUN uv pip install --verbose --no-cache-dir \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} \
     numpy \
     "cligj>=0.5" \
     "click-plugins>=1.0" \
@@ -108,7 +93,13 @@ RUN uv pip install --verbose --no-cache-dir \
 
 ## Python extensions
 COPY requirements-cpu.txt requirements.txt
-RUN uv pip install --verbose --no-cache-dir -r requirements.txt && \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} -r requirements.txt && \
     rm requirements.txt
 
-
+# Fail the build if anything silently reverted to a vendored GDAL
+RUN python -c "\
+import rasterio, fiona, pyogrio, subprocess, sys;\
+sysgdal = subprocess.run(['gdal-config','--version'], capture_output=True, text=True).stdout.strip();\
+seen = {'rasterio': rasterio.__gdal_version__, 'fiona': fiona.__gdal_version__, 'pyogrio': pyogrio.__gdal_version_string__};\
+bad = {k: v for k, v in seen.items() if v != sysgdal};\
+sys.exit('ERROR: not linked against system GDAL %s: %s' % (sysgdal, bad)) if bad else print('all Python bindings on system GDAL', sysgdal)"

--- a/extend/Dockerfile.cuda
+++ b/extend/Dockerfile.cuda
@@ -1,92 +1,68 @@
 ARG BASE=rocker/cuda
-ARG GDAL_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.10.3
 
-# Stage 1: Get GDAL binaries with Arrow/Parquet support from official image
-FROM ${GDAL_IMAGE} AS gdal-builder
-# The upstream GDAL image ships an Apache Arrow apt source whose signing key has
-# rotated, breaking `apt-get update`. Arrow libs are already baked into the image
-# and we only need libgeos-dev (from Ubuntu's own repos), so drop the stale source.
-RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources && \
-    apt-get update && apt-get install -y libgeos-dev
+# Stage 1: build GDAL's Arrow/Parquet drivers as plugins.
+#
+# Ubuntu ships GDAL without these drivers -- libarrow-dev is not in GDAL's
+# Build-Depends, so cmake never finds Arrow and the code is simply absent from
+# libgdal. Upstream builds them as dlopen'd plugins precisely so they can be
+# added without touching libgdal, which is what we do here: compile the two
+# driver targets against the *distro's* GDAL and Arrow, keep the two .so files,
+# throw the rest of the build away.
+#
+# Building from $BASE rather than a bare ubuntu image is deliberate: it
+# guarantees the same apt sources, so the plugin is compiled against exactly the
+# libgdal and libarrow the final image will load it into. Plugin and host must
+# agree on both ABIs.
+FROM $BASE AS plugin-builder
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build ca-certificates curl \
+    libgdal-dev libarrow-dev libparquet-dev libarrow-dataset-dev libarrow-acero-dev
+WORKDIR /src
+RUN GDAL_VER="$(gdal-config --version)" && \
+    echo "Building Arrow/Parquet plugins for GDAL ${GDAL_VER}" && \
+    curl -sL "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VER}/gdal-${GDAL_VER}.tar.gz" \
+      | tar xz && \
+    mv "gdal-${GDAL_VER}" gdal && \
+    cmake -S gdal -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_APPS=OFF -DBUILD_TESTING=OFF \
+      -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JAVA_BINDINGS=OFF -DBUILD_CSHARP_BINDINGS=OFF \
+      -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+      -DGDAL_USE_ARROW=ON -DGDAL_USE_PARQUET=ON -DGDAL_USE_ARROWDATASET=ON \
+      -DOGR_ENABLE_DRIVER_ARROW=ON -DOGR_ENABLE_DRIVER_ARROW_PLUGIN=ON \
+      -DOGR_ENABLE_DRIVER_PARQUET=ON -DOGR_ENABLE_DRIVER_PARQUET_PLUGIN=ON && \
+    cmake --build build --target ogr_Parquet ogr_Arrow -j"$(nproc)" && \
+    mkdir /plugins && cp build/gdalplugins/ogr_Parquet.so build/gdalplugins/ogr_Arrow.so /plugins/
 
-# Detect architecture and set allow-list path
-RUN export ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        export ARCH_TRIPLET="x86_64-linux-gnu"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        export ARCH_TRIPLET="aarch64-linux-gnu"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    mkdir -p /opt/rootfs/usr/bin && \
-    mkdir -p /opt/rootfs/usr/include && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET} && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig && \
-    mkdir -p /opt/rootfs/usr/lib/${ARCH_TRIPLET}/cmake && \
-    mkdir -p /opt/rootfs/usr/local && \
-    cp -r /usr/local/* /opt/rootfs/usr/local/ && \
-    \
-    cp /usr/bin/gdal-config /opt/rootfs/usr/bin/ && \
-    cp /usr/bin/geos-config /opt/rootfs/usr/bin/ && \
-    cp -r /usr/include/* /opt/rootfs/usr/include/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgdal* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libproj* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libgeos* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libarrow* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libparquet* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libjxl* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp /usr/lib/${ARCH_TRIPLET}/libQB3* /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    cp -r /usr/lib/${ARCH_TRIPLET}/cmake /opt/rootfs/usr/lib/${ARCH_TRIPLET}/ && \
-    \
-    # Copy pkgconfig files
-    cp /usr/lib/${ARCH_TRIPLET}/pkgconfig/gdal.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/ && \
-    cp /usr/local/lib/pkgconfig/proj.pc /opt/rootfs/usr/lib/${ARCH_TRIPLET}/pkgconfig/
-
-# Stage 2: Build our spatial image
-FROM $BASE 
+# Stage 2: the spatial image
+FROM $BASE
 
 USER root
 
-# Copy all staged files from the builder
-COPY --from=gdal-builder /opt/rootfs /
-
-# Set up environment variables
-# We use a trick to dynamically set PKG_CONFIG_PATH based on available directories
-RUN if [ -d "/usr/lib/aarch64-linux-gnu" ]; then \
-        echo "Detected aarch64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    else \
-        echo "Detected x86_64"; \
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig" >> /etc/environment; \
-    fi
-
-ENV PATH="/usr/local/bin:$PATH"
-ENV GDAL_CONFIG=/usr/bin/gdal-config
-# Set a default for build time, though /etc/environment handles runtime
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig
-
-# Install runtime dependencies for GDAL
+# GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
+# packages are needed because the Python spatial packages below are built from
+# source against them.
+# Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
+# r-cran-* binaries, and with the lists emptied it cannot find them and silently
+# falls back to compiling every R package from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libopenjp2-7 libcairo2 \
-    libpng16-16t64 libjpeg-turbo8 libgif7 liblzma5 \
-    libxml2 libexpat1 libxerces-c3.2 \
-    libnetcdf-c++4-1 libpoppler134 libspatialite8 \
-    libhdf4-0-alt libhdf5-103-1t64 libfreexl1 unixodbc libwebp7 \
-    liblcms2-2 libpcre3 libfyba0 \
-    libkmlbase1 libkmldom1 libkmlengine1 \
-    libmysqlclient21 libcfitsio10t64 libzstd1 libpq5 \
-    libarmadillo12 libopenexr-3-1-30 libheif1 libavif16 \
-    libdeflate0 libblosc1 liblz4-1 libbrotli1 \
-    libarchive13t64 libcrypto++8t64 libjxl0.7 liblerc4 \
-    libsz2 librasterlite2-1 \
-    && ldconfig \
-    && rm -rf /var/lib/apt/lists/*
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    proj-bin \
+    libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
 
+COPY --from=plugin-builder /plugins /tmp/plugins
+RUN PLUGDIR="/usr/lib/$(gcc -print-multiarch)/gdalplugins" && \
+    mkdir -p "$PLUGDIR" && mv /tmp/plugins/*.so "$PLUGDIR/" && rmdir /tmp/plugins && \
+    ogrinfo --formats | grep -q '^  Parquet ' || \
+      { echo "ERROR: Parquet driver did not load -- plugin/libgdal ABI mismatch?"; exit 1; }
 
-# GDAL environment
 ENV CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES
-ENV GDAL_DATA=/usr/local/share/gdal
-ENV PROJ_DATA=/usr/local/share/proj
+# pyproj's sdist looks for the proj executable and headers under PROJ_DIR
+ENV PROJ_DIR=/usr
 
 ## Ensure RStudio has access to environment variables
 RUN curl -s https://raw.githubusercontent.com/rocker-org/ml/refs/heads/master/set_renviron.sh | bash
@@ -98,8 +74,16 @@ COPY install.r install.r
 RUN Rscript install.r && \
     rm -rf /tmp/* /var/tmp/*
 
+# Build the GEOS/PROJ/GDAL-linked packages from source against the system
+# libraries rather than taking wheels that vendor their own copies. Otherwise
+# the image carries several GDALs, which one you get depends on whether a wheel
+# happens to exist for this Python, and the vendored copies cannot see the
+# Parquet plugin installed above.
+ENV SPATIAL_NO_BINARY="--no-binary rasterio --no-binary fiona --no-binary pyogrio \
+--no-binary pyproj --no-binary shapely"
+
 # Pre-install core spatial packages to avoid complex resolution backtracking
-RUN uv pip install --verbose --no-cache-dir \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} \
     numpy \
     "cligj>=0.5" \
     "click-plugins>=1.0" \
@@ -110,5 +94,13 @@ RUN uv pip install --verbose --no-cache-dir \
 
 ## Python extensions
 COPY requirements.cuda.txt requirements.txt
-RUN uv pip install --verbose --no-cache-dir -r requirements.txt && \
+RUN uv pip install --verbose --no-cache-dir ${SPATIAL_NO_BINARY} -r requirements.txt && \
     rm requirements.txt
+
+# Fail the build if anything silently reverted to a vendored GDAL
+RUN python -c "\
+import rasterio, fiona, pyogrio, subprocess, sys;\
+sysgdal = subprocess.run(['gdal-config','--version'], capture_output=True, text=True).stdout.strip();\
+seen = {'rasterio': rasterio.__gdal_version__, 'fiona': fiona.__gdal_version__, 'pyogrio': pyogrio.__gdal_version_string__};\
+bad = {k: v for k, v in seen.items() if v != sysgdal};\
+sys.exit('ERROR: not linked against system GDAL %s: %s' % (sysgdal, bad)) if bad else print('all Python bindings on system GDAL', sysgdal)"

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,15 +9,43 @@ This folder contains the spatial extension images (`rocker/cuda-spatial` and `ro
 
 ## Key Features
 
-### GDAL with Arrow/Parquet Support
+### GDAL
 
-These images use a **multi-stage build** to include GDAL 3.10 with full Arrow/Parquet/GeoParquet support:
+These images use the GDAL that ships with the Ubuntu base (GDAL 3.12 on Ubuntu
+26.04). Everything binds that one library:
 
-- **GeoParquet** - Read/write GeoParquet files directly with GDAL
-- **Arrow** - Apache Arrow integration for high-performance data exchange
-- **Parquet** - Native Parquet format support in GDAL
+- R's `sf`/`terra` come from r2u as prebuilt binaries linked against it
+- the Python packages that wrap GEOS/PROJ/GDAL (`rasterio`, `fiona`, `pyogrio`,
+  `pyproj`, `shapely`) are built from source against it, rather than taking
+  wheels that vendor their own copies
+- `gdal-bin` provides `ogrinfo`/`ogr2ogr` against the same library
 
-The GDAL libraries are copied from the official `ghcr.io/osgeo/gdal:ubuntu-full` image, which is built with all drivers enabled including Arrow/Parquet support that Ubuntu's default GDAL package lacks.
+The build fails if any Python binding reports a GDAL version other than
+`gdal-config --version`, so a wheel silently reintroducing a second GDAL is a
+build error rather than a surprise at runtime.
+
+### Arrow/Parquet
+
+Ubuntu does not enable GDAL's Arrow/Parquet drivers -- `libarrow-dev` is not in
+GDAL's `Build-Depends`, and no Ubuntu package ships the drivers separately.
+Upstream builds them as plugins, so these images compile just those two drivers
+from the matching GDAL source against the distro's libgdal and libarrow, and
+install them into `gdalplugins/`.
+
+The result is `(Geo)Parquet` and `(Geo)Arrow` read/write available everywhere
+that binds GDAL -- `sf`, `terra`, `ogr2ogr`, `pyogrio`, `fiona`, `geopandas` --
+including remote files over `/vsis3` and `/vsicurl`:
+
+```r
+st_write(nc, "out.parquet", driver = "Parquet")
+st_read("/vsis3/bucket/data.parquet")
+```
+
+Note `sf` does not map the `.parquet` extension to a driver, so `driver =
+"Parquet"` is required when writing. Reading auto-detects.
+
+The `arrow` and `geoarrow` R packages are also installed, with S3 and GCS
+support, for working with (Geo)Parquet outside GDAL.
 
 ### Included Packages
 

--- a/extend/install.r
+++ b/extend/install.r
@@ -5,6 +5,8 @@ install.packages(c(
 'rstac',
 'terra',
 'mapgl',
-'gifski'))
+'gifski',
+'arrow',
+'geoarrow'))
 
 

--- a/extend/requirements-cpu.txt
+++ b/extend/requirements-cpu.txt
@@ -1,5 +1,5 @@
 # Geospatial and data science extensions for CPU image
-# Note: GDAL with Arrow/Parquet support is installed from system via multi-stage build
+# Note: GDAL comes from the Ubuntu base; see extend/README.md
 
 # Cloud and storage
 boto3

--- a/extend/requirements.cuda.txt
+++ b/extend/requirements.cuda.txt
@@ -1,5 +1,5 @@
 # Geospatial and data science extensions for RAPIDS GPU image
-# Note: GDAL with Arrow/Parquet support is installed from system via multi-stage build
+# Note: GDAL comes from the Ubuntu base; see extend/README.md
 
 # Cloud and storage
 boto3


### PR DESCRIPTION
Third of three. **Based on `ubuntu-26.04-base` (#54), not master** — it needs the 26.04 base to build. Merge last.

**CI on this PR will fail until #54 has merged and published.** The spatial workflows build `--build-arg BASE=rocker/ml`, i.e. the *published* base, so they validate this branch's Dockerfile against master's 24.04 image and stop at `E: Unable to locate package libarrow-dev`. Expected; see the note at the bottom.

## The copied GDAL was never used

The spatial images copied a whole GDAL out of `ghcr.io/osgeo/gdal`, but nothing linked it. Measured in the current `latest`:

| consumer | GDAL actually loaded | source |
|---|---|---|
| R `sf` / `terra` | 3.8.4 | Ubuntu apt, pulled by bspm/r2u |
| `rasterio` | 3.9.3 | vendored in wheel |
| `fiona` | 3.9.2 | vendored in wheel |
| copied `libgdal.so.38` | 3.12.4 | **nothing links to it** |

r2u installs prebuilt `r-cran-sf`/`terra` against the distro libgdal, and the Python wheels vendor their own, so the `gdal-config` pointing at the copied library was never consulted. The image shipped two GDALs, no `gdalinfo`/`ogr2ogr` at all, and no working Parquet driver despite the README advertising one.

With the base on 26.04 the distro GDAL is 3.12, so use it directly: the builder stage, the arch-triplet `cp` block and the 41-line soname list all go (closes #51 — that list is precisely what blocked a 26.04 bump).

## Arrow/Parquet as a plugin

Ubuntu does not enable these drivers. Not a component or architecture constraint — `gdal-bin`, `libgdal38`, `libarrow-dev`, `libparquet2300` are all universe, all `arch=any` — it is that `libarrow-dev` is not in GDAL's `Build-Depends`, so cmake never finds Arrow. Coupling GDAL, a transition hub, to a library whose soname bumps quarterly is the tradeoff being avoided. Upstream's answer is to build the drivers as dlopen'd plugins, which is how Alpine and conda-forge ship them; Debian just hasn't packaged that binary.

So build those two driver targets from the matching GDAL source against the distro's libgdal and libarrow (~60s), and install them into `gdalplugins/`. The builder stage runs `FROM $BASE`, so the plugin is compiled against exactly the libraries it gets loaded into, and the build asserts the driver loads rather than shipping an inert `.so`.

## One GDAL everywhere

Python packages wrapping GEOS/PROJ/GDAL are built from source against the system libraries instead of taking wheels that vendor their own. This was previously nondeterministic — whether a package used the system GDAL depended on whether a wheel happened to exist for the image's Python:

```
before:  ml-spatial    rasterio 1.4.3  gdal 3.12.2  system-linked
         cuda-spatial  rasterio 1.5.1  gdal 3.12.4  vendored
after:   both          rasterio        gdal 3.12.2  system-linked
```

It also matters for the plugin: a vendored GDAL cannot see drivers in the system `gdalplugins/`, and `pyogrio` is geopandas' default engine, so leaving the wheels would have given Parquet to R and not to Python. The build fails if any binding reports a GDAL version other than `gdal-config --version`.

## Verified

```
ogrinfo --formats                            → Parquet (rw+uv), Arrow (rw+v)
sf     st_write(driver="Parquet") + st_read  → 100 features, epsg 4267
terra  writeVector(filetype="Parquet")       → 12 features
pyogrio / fiona                              → Parquet rw, gdal 3.12.2
sf      /vsis3 Overture GeoParquet           → 3 features, MULTIPOLYGON
pyogrio /vsis3 Overture GeoParquet           → 3 features, MultiPolygon
```

`ml-spatial` 10.1GB → 9.22GB, despite adding the plugin and the source builds.

`sf` does not map the `.parquet` extension to a driver, so `driver = "Parquet"` is required when writing; reading auto-detects. `arrow` and `geoarrow` are also installed as an out-of-GDAL path, with `s3` and `gcs` enabled (checked against public S3 and GCS buckets).

**Not verified:** arm64, and GPU execution for the CUDA variant.

## Follow-up worth considering

The spatial workflows building against the *published* base means a PR that changes base and spatial together can never go green — the same class of problem as the CUDA image fetching its scripts from `master` (fixed in #54). Building the base in-job for PRs and passing `BASE=<local tag>` would close it, at roughly double the PR build time.
