### PR TITLE
Fix sudo resolving to the system python instead of the venv

### DIFF
--- a/.github/workflows/build-cuda.yml
+++ b/.github/workflows/build-cuda.yml
@@ -12,6 +12,7 @@ on:
       - Rprofile
       - vscode-extensions.txt
       - requirements.cuda.txt
+      - sudoers-venv
       - .github/workflows/build-cuda.yml
 
 # Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,

--- a/.github/workflows/build-ml.yml
+++ b/.github/workflows/build-ml.yml
@@ -12,6 +12,7 @@ on:
       - Rprofile
       - vscode-extensions.txt
       - requirements-cpu.txt
+      - sudoers-venv
       - .github/workflows/build-ml.yml
 
 # Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,20 @@ A simple `CMD ["jupyter", "lab", ...]` is acceptable as a local-testing fallback
 Do not use CMD to run setup scripts that copy configs or seed state at container start.
 JupyterHub overrides CMD, so such scripts will never run in production.
 
+### sudo, secure_path and Ubuntu 26.04's sudo-rs
+`sudo` resolves commands with `secure_path` from `/etc/sudoers`, not the caller's PATH,
+and Ubuntu's default does not include `${VIRTUAL_ENV}/bin`. Left alone, `sudo pip install`
+silently installs into the **system** python instead of `/opt/venv`, and `sudo jupyter`
+is not found. Fixed by `sudoers-venv`, installed as `/etc/sudoers.d/zz-venv`.
+
+Ubuntu 26.04 also makes **sudo-rs** the default `/usr/bin/sudo` (GNU sudo remains at
+`/usr/bin/sudo.ws`). sudo-rs does **not** implement `--preserve-env` -- it warns and
+ignores it -- so do not rely on that flag to carry the environment across a privilege
+drop. Use `Defaults env_keep`, which sudo-rs does honour.
+
+The `zz-` prefix is deliberate: `sudoers.d` is read in lexical order and later `Defaults`
+win, so anything setting `secure_path` must sort last.
+
 ## Persistent Storage Pattern
 
 All persistent, image-baked configuration must live outside `$HOME`.

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -64,6 +64,12 @@ RUN bash install_utilities.sh
 RUN apt-get update && apt-get -y install sudo && \
     usermod -aG sudo "$NB_USER" && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
+# Put ${VIRTUAL_ENV}/bin on sudo's secure_path and keep the venv/Jupyter env
+# vars across a privilege drop. Without this `sudo pip` silently installs into
+# the system python and `sudo jupyter` is not found; see sudoers-venv.
+COPY sudoers-venv /etc/sudoers.d/zz-venv
+RUN chmod 0440 /etc/sudoers.d/zz-venv && visudo -c -f /etc/sudoers.d/zz-venv
+
 # Install R
 COPY install_r.sh install_r.sh
 RUN bash install_r.sh

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -69,6 +69,12 @@ RUN bash install_utilities.sh
 ## Grant user sudoer privileges
 RUN adduser "$NB_USER" sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
+# Put ${VIRTUAL_ENV}/bin on sudo's secure_path and keep the venv/Jupyter env
+# vars across a privilege drop. Without this `sudo pip` silently installs into
+# the system python and `sudo jupyter` is not found; see sudoers-venv.
+COPY sudoers-venv /etc/sudoers.d/zz-venv
+RUN chmod 0440 /etc/sudoers.d/zz-venv && visudo -c -f /etc/sudoers.d/zz-venv
+
 # Install R
 COPY install_r.sh install_r.sh
 RUN bash install_r.sh

--- a/sudoers-venv
+++ b/sudoers-venv
@@ -1,0 +1,34 @@
+# Make `sudo` behave sensibly in an image whose Python lives in a venv.
+#
+# Two separate problems are addressed here.
+#
+# 1. secure_path (long-standing, not new to 26.04)
+#
+#    Ubuntu's /etc/sudoers sets a secure_path that does not include
+#    ${VIRTUAL_ENV}/bin, and sudo resolves the command with secure_path rather
+#    than the caller's PATH. So for a user in this image:
+#
+#      sudo pip install X    -> silently runs /usr/lib/python3/dist-packages/pip
+#                               and installs into the SYSTEM python, not /opt/venv
+#      sudo python3 ...      -> /usr/bin/python3, not the venv interpreter
+#      sudo jupyter ...      -> "command not found"
+#
+#    The first is the dangerous one: it does not fail, it quietly targets the
+#    wrong interpreter, so packages appear to install and then are missing.
+#
+# 2. --preserve-env (new in Ubuntu 26.04)
+#
+#    26.04 makes sudo-rs the default /usr/bin/sudo via update-alternatives.
+#    sudo-rs does not implement --preserve-env: it warns and ignores the flag.
+#    Anything that drops root -> ${NB_USER} with `sudo --preserve-env` therefore
+#    loses the environment. In this stack XDG_CONFIG_HOME and CODE_EXTENSIONSDIR
+#    are load-bearing -- they are what keep app config and code-server
+#    extensions outside the JupyterHub $HOME mount -- so losing them silently
+#    relocates both into $HOME. sudo-rs does honour env_keep, so the variables
+#    are listed explicitly instead of replacing Ubuntu's default sudo.
+#
+# The zz- filename prefix matters: sudoers.d is read in lexical order and later
+# Defaults win, so this must sort after any other drop-in that sets secure_path.
+# jupyter/docker-stacks' start.sh, for example, generates /etc/sudoers.d/path.
+Defaults secure_path="/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults env_keep += "VIRTUAL_ENV NB_USER NB_UID NB_GID CODE_EXTENSIONSDIR XDG_CONFIG_HOME LD_LIBRARY_PATH PYTHONPATH"


### PR DESCRIPTION
Found while moving `rocker/binder` onto `rocker/ml-spatial` (rocker-org/binder#62).

## The main bug: `sudo pip` installs into the wrong Python

`sudo` resolves the command using `secure_path` from `/etc/sudoers`, **not** the caller's `PATH`, and Ubuntu's default `secure_path` does not include `${VIRTUAL_ENV}/bin`. In these images that means:

```
sudo pip install X   ->  runs /usr/lib/python3/dist-packages/pip
                         and installs into the SYSTEM python, not /opt/venv
sudo python3 ...     ->  /usr/bin/python3, not the venv interpreter
sudo jupyter ...     ->  "command not found"
```

The first one is the harmful case. It does not fail — it quietly targets the wrong interpreter, so a package looks installed and is then missing from the environment the user is actually working in. Given that `jovyan` has passwordless sudo and "just use sudo" is the natural reaction to a permissions error, this is easy to hit.

**This is long-standing, not a 26.04 regression.** `rocker/ml:py3.12` on 24.04 with GNU sudo 1.9.15p5 behaves identically — I checked before writing this up.

## Secondary: 26.04 replaces GNU sudo with sudo-rs

Ubuntu 26.04 makes **sudo-rs** the default `/usr/bin/sudo` via `update-alternatives` (GNU sudo is still installed, at `/usr/bin/sudo.ws`). sudo-rs does **not** implement `--preserve-env`; it warns and ignores the flag:

```
sudo: preserving the entire environment is not supported, '--preserve-env' is ignored
```

So anything that drops `root` → `${NB_USER}` via `sudo --preserve-env` loses the environment. `XDG_CONFIG_HOME` and `CODE_EXTENSIONSDIR` are load-bearing in this stack — they are what keep app config and code-server extensions outside the JupyterHub `$HOME` mount — so losing them silently relocates both into `$HOME`, which is exactly what `AGENTS.md` warns against.

`rocker/ml` itself does not currently drop privileges this way, so it is not broken today. It surfaced downstream: `rocker/binder` restores docker-stacks' `start.sh`, which does. Fixing it here means derivatives inherit a sane `sudo` instead of each rediscovering this.

sudo-rs *does* honour `env_keep`, so the variables are listed explicitly rather than replacing Ubuntu's default sudo.

## The fix

One drop-in, `sudoers-venv`, installed to `/etc/sudoers.d/zz-venv` in both `Dockerfile.cpu` and `Dockerfile.cuda`, with `visudo -c` validating the syntax at build time.

The `zz-` prefix is load-bearing: `sudoers.d` is read in lexical order and later `Defaults` win, so this must sort after any other drop-in that sets `secure_path` — docker-stacks' `start.sh`, for example, generates `/etc/sudoers.d/path` and would otherwise clobber it.

## Verification

Applied to `rocker/ml-spatial:latest`, before → after:

| command | before | after |
|---|---|---|
| `sudo pip --version` | system `pip 25.1.1` (`/usr/lib/python3/dist-packages`) | `/opt/venv/.../pip 26.2.1` |
| `sudo python3 -c 'sys.executable'` | `/usr/bin/python3` | `/opt/venv/bin/python3` |
| `sudo jupyter --version` | `command not found` | runs |
| `sudo apt-get --version` | works | works (control, unaffected) |
| `sudo bash -c 'echo $XDG_CONFIG_HOME $CODE_EXTENSIONSDIR'` | both empty | `/opt/share/xdg-config`, `/opt/share/code-server` |

Not yet verified: a full image build on either arch (CI will cover it) and the CUDA variant, where the change is textually identical to the CPU one.
