### PR TITLE
Build /opt/venv with --copies so code-server can discover it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,54 @@ drop. Use `Defaults env_keep`, which sudo-rs does honour.
 The `zz-` prefix is deliberate: `sudoers.d` is read in lexical order and later `Defaults`
 win, so anything setting `secure_path` must sort last.
 
+## The venv must be built with `--copies`
+
+`/opt/venv` is created with `python3 -m venv --copies`. **Do not drop `--copies`.**
+
+A default venv symlinks `bin/python -> bin/python3 -> /usr/bin/pythonX.Y`, so its
+`realpath` is the *system* interpreter. The VS Code Python extension's PATH locator
+canonicalises every candidate and dedupes by resolved path, so the venv resolves to
+the same file as `/usr/bin/python3` and is silently discarded. The symptom is that
+`/opt/venv` never appears in the interpreter picker or the notebook kernel picker --
+only `/bin/python3` and `/usr/bin/python3` -- even though `/opt/venv/bin` is first on
+`PATH` and `$VIRTUAL_ENV` points at it. The extension log shows the collapse:
+
+```
+Found: /opt/venv/bin/python --> /usr/bin/python3.14   # seen, then deduped away
+> /bin/python3      ... interpreterInfo.py            # only these two survive
+> /usr/bin/python3  ... interpreterInfo.py
+```
+
+Being on `PATH` is the one way of being found that does *not* survive this, because
+the PATH locator is the only one that dedupes. The venv locators (which key off
+`pyvenv.cfg` and would preserve its identity) never see `/opt/venv`, since it is in
+none of the directories they scan (`~/.virtualenvs`, `$WORKON_HOME`, `python.venvPath`,
+or the workspace).
+
+`--copies` gives the venv its own real interpreter binary, so its `realpath` stays
+inside `/opt/venv` and it keeps a distinct identity. Cost is ~20MB.
+
+A `python.venvPath` setting also works around this, but it would have to be seeded
+into each user's `settings.json` at runtime (it cannot be baked into `$HOME`);
+`--copies` fixes it at the source and needs no settings at all.
+
+### Open VSX ships the pet-less build of ms-python
+
+Related, and worth knowing before debugging this area: `code-server --install-extension
+ms-python.python` resolves against **Open VSX**, which only ever serves the `universal`
+VSIX. That build omits the `pet` native locator binary (`python-env-tools/bin/pet`) that
+Microsoft bundles in the per-platform VSIXs. `ms-python.vscode-python-envs` -- pulled in
+automatically as an `extensionPack` member -- shells out to `pet` for all discovery, so
+it fails with `ENOENT` and reports zero environments, leaving its "Python Environments"
+UI offering only *Create Environment*.
+
+This is mostly cosmetic today: `python.useEnvironmentsExtension` defaults to `false`, so
+`ms-python.python`'s own legacy locator (which needs no `pet`) is authoritative, and that
+is also what `ms-toolsai.jupyter` consumes for notebook kernels. The `pet` binary is not
+separately distributed -- `microsoft/python-environment-tools` publishes no release
+assets -- so the only source is the Microsoft marketplace, whose terms target VS Code
+proper. Hence: not vendored here.
+
 ## Persistent Storage Pattern
 
 All persistent, image-baked configuration must live outside `$HOME`.

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -48,7 +48,16 @@ RUN apt-get update && apt-get install -y \
 #   pip installs run as jovyan can freely update any package.
 # - chown in a SEPARATE RUN layer would duplicate every venv file, doubling image size.
 COPY requirements-cpu.txt /tmp/requirements.txt
-RUN python3 -m venv $VIRTUAL_ENV && \
+# --copies is deliberate: without it VS Code / code-server cannot see this venv.
+# A default (symlinked) venv makes bin/python a symlink chain ending at
+# /usr/bin/pythonX.Y -- the *same* real path as the system interpreter. The Python
+# extension's PATH locator canonicalises candidates and dedupes by resolved path,
+# so the venv collapses into the system python and silently disappears from the
+# interpreter and notebook-kernel pickers, even though it is first on PATH and
+# $VIRTUAL_ENV points at it. --copies gives the venv a real interpreter binary of
+# its own, so it keeps a distinct identity and is discovered normally.
+# Costs ~20MB (three copies of the ~7MB binary) against a multi-GB image.
+RUN python3 -m venv --copies $VIRTUAL_ENV && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir -r /tmp/requirements.txt && \
     chown -R $NB_USER:$NB_USER $VIRTUAL_ENV

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -51,7 +51,16 @@ RUN apt-get update && apt-get install -y \
 #   pip installs run as jovyan can freely update any package.
 # - chown in a SEPARATE RUN layer would duplicate every venv file, doubling image size.
 COPY requirements.cuda.txt /tmp/requirements.txt
-RUN python3 -m venv $VIRTUAL_ENV && \
+# --copies is deliberate: without it VS Code / code-server cannot see this venv.
+# A default (symlinked) venv makes bin/python a symlink chain ending at
+# /usr/bin/pythonX.Y -- the *same* real path as the system interpreter. The Python
+# extension's PATH locator canonicalises candidates and dedupes by resolved path,
+# so the venv collapses into the system python and silently disappears from the
+# interpreter and notebook-kernel pickers, even though it is first on PATH and
+# $VIRTUAL_ENV points at it. --copies gives the venv a real interpreter binary of
+# its own, so it keeps a distinct identity and is discovered normally.
+# Costs ~20MB (three copies of the ~7MB binary) against a multi-GB image.
+RUN python3 -m venv --copies $VIRTUAL_ENV && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir -r /tmp/requirements.txt && \
     chown -R $NB_USER:$NB_USER $VIRTUAL_ENV


### PR DESCRIPTION
## Problem

`/opt/venv` is invisible to code-server. The interpreter picker and the notebook
kernel picker offer only `/bin/python3` and `/usr/bin/python3` — never the venv —
even though `/opt/venv/bin` is first on `PATH` and `$VIRTUAL_ENV` points at it.
Users can't select the environment that actually has the image's packages in it,
and the only offered action is "Create Environment".

## Cause

A default `python3 -m venv` symlinks `bin/python -> bin/python3 -> /usr/bin/pythonX.Y`,
so the venv's `realpath` **is** the system interpreter. The VS Code Python extension's
PATH locator canonicalises every candidate and dedupes by resolved path, so `/opt/venv`
collapses into `/usr/bin/python3` and is discarded. From `ms-python.python`'s log:

```
Found: /opt/venv/bin/python --> /usr/bin/python3.14   # seen, then deduped away
> /bin/python3      ... interpreterInfo.py            # only these two survive
> /usr/bin/python3  ... interpreterInfo.py
Python interpreter path: /bin/python3
```

The locators that *would* preserve its identity (they key off `pyvenv.cfg`) never see
`/opt/venv`, because it's in none of the directories they scan — `~/.virtualenvs`,
`$WORKON_HOME`, `python.venvPath`, or the workspace. The PATH locator is the only one
that finds it, and the only one that dedupes. Being on `PATH` is the one way of being
found that doesn't survive this, which is why the failure looks so counterintuitive.

## Fix

`python3 -m venv --copies`, in `Dockerfile.cpu` and `Dockerfile.cuda`. The venv gets
its own interpreter binary, so its `realpath` stays inside `/opt/venv` and it keeps a
distinct identity.

Verified on the current Ubuntu 26.04 / Python 3.14 base:

| | `realpath` of `bin/python` |
|---|---|
| default | `/usr/bin/python3.14` — collides with system python |
| `--copies` | `<venv>/bin/python3` — distinct |

The `--copies` venv is fully functional: correct `sys.prefix`, `sys.prefix != sys.base_prefix`,
its own pip. Cost is ~20MB (three copies of the ~7MB binary) against a multi-GB image.

### Why not `python.venvPath`

Setting `python.venvPath: /opt` also works, but it's a *setting*, so it would have to be
seeded into every user's `settings.json` at runtime — `$HOME` is a JupyterHub volume mount,
so it can't be baked in at build time. `--copies` fixes it at the source and needs no
settings at all.

## Also

`AGENTS.md` gains a section documenting the above, plus a related note worth recording:
`code-server --install-extension ms-python.python` resolves against **Open VSX**, which only
ever serves the `universal` VSIX. That build omits the `pet` native locator binary that
Microsoft bundles in the per-platform VSIXs, so `ms-python.vscode-python-envs` (auto-installed
as an `extensionPack` member) fails with `ENOENT` and reports zero environments.

This is mostly cosmetic today — `python.useEnvironmentsExtension` defaults to `false`, so
ms-python's own legacy locator is authoritative, and that's also what `ms-toolsai.jupyter`
uses for notebook kernels. I deliberately did **not** vendor `pet`: it isn't separately
distributed (`microsoft/python-environment-tools` publishes no release assets), so the only
source is the Microsoft marketplace, whose terms target VS Code proper. Flagging it so the
next person doesn't rediscover it.

## Test plan

CI builds both images (this touches `Dockerfile.cpu` and `Dockerfile.cuda`, so both
workflows trigger). After a build, in code-server: `/opt/venv` should appear in the
interpreter picker and as a notebook kernel, and be selected by default.
