### PR TITLE
Pre-install and pre-configure Posit Assistant in RStudio

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,126 @@
+name: Build PR image (test)
+
+# Build the base images from a pull request and publish them under a
+# throwaway `pr-<number>` tag, so a change can be pulled and poked at by hand
+# before it is merged. The release workflows (build-ml.yml / build-cuda.yml)
+# only run on push to master, which means without this the first real build of
+# a change is also the build that overwrites `:latest`.
+#
+# Differences from the release workflows, all deliberate:
+#   - amd64 only. This is a test artifact, not a release; arm64 doubles the
+#     cost for something that gets deleted in a week.
+#   - GHCR only. Docker Hub is the user-facing registry and needs org secrets
+#     that forks cannot read; GITHUB_TOKEN is enough for GHCR.
+#   - Tags `pr-<number>`, never `latest`. Nothing here can shadow a release.
+#
+# These tags are not garbage-collected. Prune them occasionally from
+# https://github.com/orgs/rocker-org/packages (Package settings -> versions).
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which image to build
+        type: choice
+        options: [both, cpu, cuda]
+        default: both
+  pull_request:
+    paths:
+      - Dockerfile.cpu
+      - Dockerfile.cuda
+      - install*.sh
+      - Rprofile
+      - smoke-test.sh
+      - vscode-extensions.txt
+      - requirements-cpu.txt
+      - requirements.cuda.txt
+      - sudoers-venv
+      - .github/workflows/build-pr.yml
+
+concurrency:
+  # One in-flight build per PR; a new push supersedes the previous build.
+  group: build-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }} (amd64)
+    # Fork PRs cannot push to the org's registry (GITHUB_TOKEN is read-only
+    # for them). Skip rather than fail with a confusing 403.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # `matrix` is not available to a job-level `if`, so the workflow_dispatch
+        # choice is applied by shortening the matrix itself. On pull_request the
+        # `inputs` context is empty and both images build.
+        image: ${{ fromJSON(inputs.target == 'cpu' && '["cpu"]' || inputs.target == 'cuda' && '["cuda"]' || '["cpu","cuda"]') }}
+    steps:
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: actions/checkout@v5
+
+      - name: Resolve image parameters
+        id: img
+        run: |
+          case "${{ matrix.image }}" in
+            cpu)  echo "dockerfile=Dockerfile.cpu"  >> "$GITHUB_OUTPUT"
+                  echo "repo=ghcr.io/rocker-org/ml" >> "$GITHUB_OUTPUT" ;;
+            cuda) echo "dockerfile=Dockerfile.cuda"   >> "$GITHUB_OUTPUT"
+                  echo "repo=ghcr.io/rocker-org/cuda" >> "$GITHUB_OUTPUT" ;;
+          esac
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            tag="pr-${{ github.event.pull_request.number }}"
+          else
+            # Manual run off a branch: sanitize the ref into a valid tag.
+            tag="dev-$(echo '${{ github.ref_name }}' | tr -c 'a-zA-Z0-9._-' '-')"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ steps.img.outputs.dockerfile }}
+          platforms: linux/amd64
+          build-args: |
+            NB_USER=jovyan
+          tags: ${{ steps.img.outputs.repo }}:${{ steps.img.outputs.tag }}
+          push: true
+
+      # Cheap assertions that the image is actually usable, so an obviously
+      # broken build fails here instead of during hand-testing.
+      - name: Smoke test
+        run: bash smoke-test.sh "${{ steps.img.outputs.repo }}:${{ steps.img.outputs.tag }}"
+
+      - name: Summary
+        if: always()
+        run: |
+          ref="${{ steps.img.outputs.repo }}:${{ steps.img.outputs.tag }}"
+          {
+            echo "### \`${{ matrix.image }}\` test image"
+            echo
+            echo '```'
+            echo "docker pull ${ref}"
+            echo "docker run --rm -p 8888:8888 -e OPENAI_API_KEY=\$OPENAI_API_KEY ${ref}"
+            echo '```'
+            echo
+            echo "Then open <http://localhost:8888>, launch RStudio, and check the Posit Assistant pane."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,42 @@ Two providers are enabled out of the box:
   `~/.local/share/opencode/auth.json` (HOME persistent volume) and survives container
   restarts. Alternatively, inject `GITHUB_TOKEN` via JupyterHub to skip interactive auth.
 
+## Posit Assistant Configuration
+
+RStudio 2026.04.0+ ships the AI pane, but not the assistant itself: on first use RStudio
+downloads a Node bundle from `cdn.posit.co` into `~/.local/share/rstudio/pai/bin`. That is
+a per-user, network-dependent step, so `install_posit_assistant.sh` bakes the bundle in at
+build time instead. Version and checksum are resolved from
+`https://cdn.posit.co/posit-ai/manifest.json` (keyed by wire-protocol version; we take the
+highest, matching the current stable RStudio) — nothing is pinned.
+
+Install location is `/etc/rstudio/pai/bin`, the system-wide path RStudio searches
+(`ChatInstallation.cpp`, `locatePositAssistantInstallation`):
+
+1. `$RSTUDIO_POSIT_AI_PATH`
+2. `~/.local/share/rstudio/pai/bin`
+3. `/etc/rstudio/pai/bin`  ← we use this
+
+Deliberately *not* `RSTUDIO_POSIT_AI_PATH`: that would shadow (2), so a user who lets
+RStudio update the assistant would keep getting the image-baked copy. With (3), an updated
+copy in the persistent HOME wins.
+
+Runtime config comes from `_setup_posit_assistant()` in the Jupyter startup hook. The
+assistant reads `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` for its
+"OpenAI Compatible" provider, and env vars outrank both `~/.posit/ai/providers.json` and
+the settings UI. `rserver` is spawned by jupyter-rsession-proxy as a child of the Jupyter
+server, so exporting them in the hook is enough.
+
+Model choice is *not* env-configurable in the shipping build (the documented
+`POSIT_ASSISTANT_SETTINGS_DEFAULT` / `_ENFORCED` variables are not in the 1.1.0 bundle —
+only `POSIT_AI_PROVIDERS_DEFAULT` / `_ENFORCED` for `providers.json`). So the hook seeds
+`~/.posit/assistant/settings.json` on first launch, opencode-style: HOME-resident, user
+edits persist, delete and restart to re-seed.
+
+The relevant RStudio prefs (`assistant`, `chat_provider`) already default to `posit`, so no
+`/etc/rstudio/rstudio-prefs.json` entry is needed. `RSTUDIO_DISABLE_POSIT_ASSISTANT` is the
+off switch if one is ever wanted.
+
 ## Roo Cline Configuration
 
 Roo Cline stores its API provider config in VS Code **secret storage**, which falls back to
@@ -95,3 +131,21 @@ current `OPENAI_API_KEY`).
 The `~/.local/share/code-server/User/settings.json` entry persists in the user's home
 volume once written, so new users get it on first Jupyter start and it stays for subsequent
 sessions.
+
+## Testing a change before merging
+
+The release workflows (`build-ml.yml`, `build-cuda.yml`) only run on push to `master`, and
+their `merge` job writes `:latest` — so they are not a pre-merge gate. `build-pr.yml` fills
+that gap: on a pull request touching the Dockerfiles or `install*.sh` it builds amd64-only
+images and pushes them to GHCR as `ghcr.io/rocker-org/{ml,cuda}:pr-<number>`, then runs
+`smoke-test.sh` against the result. The job summary prints the `docker pull` / `docker run`
+lines for hand-testing.
+
+`smoke-test.sh` also runs locally against any tag (`bash smoke-test.sh rocker-ml:local`,
+pairing with `run.sh`). It asserts R/Python/Jupyter/RStudio/quarto/opencode are present and
+that the Jupyter startup hook actually seeds the opencode, Roo and Posit Assistant config
+when executed with an `OPENAI_API_KEY` in the environment. It does **not** cover anything
+GPU (no GPU runners) or anything that needs a browser — the IDE panes still need a human.
+
+Fork PRs are skipped: `GITHUB_TOKEN` is read-only for them, so the push would 403. PR tags
+are not garbage-collected; prune them from the org's package settings occasionally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,17 @@ Install location is `/etc/rstudio/pai/bin`, the system-wide path RStudio searche
 2. `~/.local/share/rstudio/pai/bin`
 3. `/etc/rstudio/pai/bin`  ← we use this
 
-Deliberately *not* `RSTUDIO_POSIT_AI_PATH`: that would shadow (2), so a user who lets
-RStudio update the assistant would keep getting the image-baked copy. With (3), an updated
-copy in the persistent HOME wins.
+(3) alone is **not** enough under JupyterHub. `systemConfigDir()` is only `/etc/rstudio`
+when nothing overrides it, and `jupyter-rsession-proxy` sets `RSTUDIO_CONFIG_DIR` to a fresh
+`tempfile.mkdtemp()` for every `rserver` it spawns (`jupyter_rsession_proxy/__init__.py`).
+That variable short-circuits the entire XDG lookup, so RStudio searches `<tmpdir>/pai/bin`,
+finds nothing, and offers to download the assistant — exactly as if it were not installed.
+(The same code path is behind the `session-rpc-key` removal in `install_rstudio.sh`.)
+
+So the startup hook sets `RSTUDIO_POSIT_AI_PATH` (1) to the system path, but only when the
+user has no copy of their own in (2) — otherwise the env var would shadow an in-IDE update.
+The bundle still lives at (3) so a plain `rserver`, launched without the proxy, finds it
+with no environment help.
 
 Runtime config comes from `_setup_posit_assistant()` in the Jupyter startup hook. The
 assistant reads `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` for its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,23 +88,36 @@ Install location is `/etc/rstudio/pai/bin`, the system-wide path RStudio searche
 2. `~/.local/share/rstudio/pai/bin`
 3. `/etc/rstudio/pai/bin`  ← we use this
 
-(3) alone is **not** enough under JupyterHub. `systemConfigDir()` is only `/etc/rstudio`
-when nothing overrides it, and `jupyter-rsession-proxy` sets `RSTUDIO_CONFIG_DIR` to a fresh
-`tempfile.mkdtemp()` for every `rserver` it spawns (`jupyter_rsession_proxy/__init__.py`).
-That variable short-circuits the entire XDG lookup, so RStudio searches `<tmpdir>/pai/bin`,
-finds nothing, and offers to download the assistant — exactly as if it were not installed.
-(The same code path is behind the `session-rpc-key` removal in `install_rstudio.sh`.)
+(3) alone is **not** enough under JupyterHub, and neither is any environment variable
+exported by the Jupyter server. Two separate obstacles:
 
-So the startup hook sets `RSTUDIO_POSIT_AI_PATH` (1) to the system path, but only when the
-user has no copy of their own in (2) — otherwise the env var would shadow an in-IDE update.
-The bundle still lives at (3) so a plain `rserver`, launched without the proxy, finds it
-with no environment help.
+1. `jupyter-rsession-proxy` sets `RSTUDIO_CONFIG_DIR` to a fresh `tempfile.mkdtemp()` for
+   every `rserver` it spawns. That variable short-circuits the whole XDG lookup, so
+   `systemConfigDir()` becomes the temp dir and RStudio searches `<tmpdir>/pai/bin`.
+   (Same code path as the `session-rpc-key` removal in `install_rstudio.sh`.)
+2. `rserver` does **not** pass its environment to `rsession`. It builds a curated ~27-var
+   environment (`RS_*`, `RSTUDIO_*`, `R_*`, plus `HOME`, `PATH`, `USER`, `LOGNAME`, `LANG`,
+   `SHELL`, `LD_LIBRARY_PATH`, `XDG_CONFIG_HOME`) and drops everything else — verified on a
+   live pod: 92 vars in `rserver`, 27 in `rsession`. `/etc/rstudio/env-vars` does not help
+   either; `rserver` only `setenv()`s that into its own process.
 
-Runtime config comes from `_setup_posit_assistant()` in the Jupyter startup hook. The
-assistant reads `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` for its
+So the config goes through **R's `Renviron.site`**, which is the one channel that reaches a
+session: R `putenv()`s it into the `rsession` process at startup, and `SessionChat` launches
+the assistant's Node backend with `core::system::environment()` — the full process env — so
+the backend inherits it too. (RStudio's own source cites `~/.Renviron` as how proxy vars
+reach that backend.) This is the same reason `set_renviron.sh` exists in this repo.
+
+`install_posit_assistant.sh` writes a delimited managed block into `$(R RHOME)/etc/Renviron.site`
+with `RSTUDIO_POSIT_AI_PATH` and the provider base URL, and chowns the file to `$NB_USER`.
+The startup hook rewrites that block each start to fill in `OPENAI_COMPATIBLE_API_KEY`, which
+is a runtime secret. Keeping it there rather than in `~/.Renviron` means the key lives on the
+container filesystem and is regenerated every start, instead of persisting in the home volume
+after it is rotated. The hook drops `RSTUDIO_POSIT_AI_PATH` from the block when the user has
+their own copy in `~/.local/share/rstudio/pai/bin`, so an in-IDE update still wins.
+
+The assistant reads `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` for its
 "OpenAI Compatible" provider, and env vars outrank both `~/.posit/ai/providers.json` and
-the settings UI. `rserver` is spawned by jupyter-rsession-proxy as a child of the Jupyter
-server, so exporting them in the hook is enough.
+the settings UI.
 
 Model choice is *not* env-configurable in the shipping build (the documented
 `POSIT_ASSISTANT_SETTINGS_DEFAULT` / `_ENFORCED` variables are not in the 1.1.0 bundle —

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -78,6 +78,11 @@ RUN bash install_r.sh
 COPY install_rstudio.sh install_rstudio.sh
 RUN bash install_rstudio.sh
 
+# Posit Assistant: bake the AI-pane bundle into the image so users are not
+# prompted to download it per-session (see install_posit_assistant.sh).
+COPY install_posit_assistant.sh install_posit_assistant.sh
+RUN bash install_posit_assistant.sh
+
 COPY Rprofile /usr/lib/R/etc/Rprofile.site
 
 ## Add rstudio's binaries to path for quarto

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -84,6 +84,11 @@ COPY Rprofile /usr/lib/R/etc/Rprofile.site
 COPY install_rstudio.sh install_rstudio.sh
 RUN bash install_rstudio.sh
 
+# Posit Assistant: bake the AI-pane bundle into the image so users are not
+# prompted to download it per-session (see install_posit_assistant.sh).
+COPY install_posit_assistant.sh install_posit_assistant.sh
+RUN bash install_posit_assistant.sh
+
 
 ## Add rstudio's binaries to path for quarto
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin/quarto/bin

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To access a stable build, users may refer to specific SHA hash tags on the [GitH
 ## Features
 
 - **IDEs:** Jupyter Lab, RStudio Server, VSCode (code-server) with common extensions
-- **AI Coding Assistants:** [opencode](https://opencode.ai) CLI and VSCode extension, [Roo Cline](https://github.com/RooVeterinaryInc/roo-cline) VSCode extension
+- **AI Coding Assistants:** [opencode](https://opencode.ai) CLI and VSCode extension, [Roo Cline](https://github.com/RooVeterinaryInc/roo-cline) VSCode extension, [Posit Assistant](https://assistant.posit.co) in RStudio
 - **ML Plugins:** Tensorboard support
 - **Python:** 3.12 with pip-based environment at `/opt/venv` (user-writable)
 - **CUDA Support:** CUDA 13 runtime libraries (GPU image only)
@@ -114,11 +114,25 @@ Additional utilities and VSCode extensions are installed in `/opt/share` (via `X
 
 **Roo Cline** is configured automatically at Jupyter server start via a startup hook that reads `OPENAI_API_KEY` from the environment.
 
+**Posit Assistant** (the AI pane in RStudio) is baked into the image at `/etc/rstudio/pai/bin`,
+so users are not prompted to download it on first use. It is pointed at NRP via
+`OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` (derived from `OPENAI_API_KEY`)
+in the same startup hook, and the model is seeded into `~/.posit/assistant/settings.json`
+on first launch — edit that file, or use the assistant's own settings UI, to change models
+or switch to another provider (Posit AI, Anthropic, OpenAI, ...).
+
 The only env var required for NRP access:
 
 | Variable | Description |
 |---|---|
 | `OPENAI_API_KEY` | NRP API key |
+
+### Testing changes
+
+Pull requests that touch the Dockerfiles or install scripts build a throwaway amd64 image at
+`ghcr.io/rocker-org/ml:pr-<number>` (and `.../cuda:pr-<number>`) via `.github/workflows/build-pr.yml`,
+so a change can be pulled and tried before it is merged. `smoke-test.sh` runs against that image in
+CI and can be run locally against any tag: `bash smoke-test.sh rocker-ml:local`.
 
 ### Installing package binaries
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Additional utilities and VSCode extensions are installed in `/opt/share` (via `X
 **Roo Cline** is configured automatically at Jupyter server start via a startup hook that reads `OPENAI_API_KEY` from the environment.
 
 **Posit Assistant** (the AI pane in RStudio) is baked into the image at `/etc/rstudio/pai/bin`,
-so users are not prompted to download it on first use (the Jupyter startup hook points
-`RSTUDIO_POSIT_AI_PATH` at it, since jupyter-rsession-proxy's `RSTUDIO_CONFIG_DIR` would
-otherwise send RStudio's search to a temp directory). It is pointed at NRP via
+so users are not prompted to download it on first use. Its install path and the NRP provider
+config are passed to the RStudio session through a managed block in R's `Renviron.site` — the
+only channel that reaches `rsession`, which gets a curated environment from `rserver` rather
+than the container's. It is pointed at NRP via
 `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` (derived from `OPENAI_API_KEY`)
 in the same startup hook, and the model is seeded into `~/.posit/assistant/settings.json`
 on first launch — edit that file, or use the assistant's own settings UI, to change models

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Additional utilities and VSCode extensions are installed in `/opt/share` (via `X
 **Roo Cline** is configured automatically at Jupyter server start via a startup hook that reads `OPENAI_API_KEY` from the environment.
 
 **Posit Assistant** (the AI pane in RStudio) is baked into the image at `/etc/rstudio/pai/bin`,
-so users are not prompted to download it on first use. It is pointed at NRP via
+so users are not prompted to download it on first use (the Jupyter startup hook points
+`RSTUDIO_POSIT_AI_PATH` at it, since jupyter-rsession-proxy's `RSTUDIO_CONFIG_DIR` would
+otherwise send RStudio's search to a temp directory). It is pointed at NRP via
 `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` (derived from `OPENAI_API_KEY`)
 in the same startup hook, and the model is seeded into `~/.posit/assistant/settings.json`
 on first launch — edit that file, or use the assistant's own settings UI, to change models

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -119,6 +119,20 @@ def _setup_posit_assistant():
     if api_key:
         os.environ.setdefault("OPENAI_COMPATIBLE_API_KEY", api_key)
 
+    # RStudio finds the image-baked bundle at /etc/rstudio/pai/bin only when it
+    # resolves systemConfigDir() to /etc/rstudio. jupyter-rsession-proxy sets
+    # RSTUDIO_CONFIG_DIR to a fresh mkdtemp() for every rserver it spawns, and
+    # that variable short-circuits the whole XDG lookup -- so RStudio searches
+    # <tmpdir>/pai/bin, finds nothing, and offers to download the assistant.
+    # Point RSTUDIO_POSIT_AI_PATH (the first entry in RStudio's search order) at
+    # the real location instead. Skipped when the user already has their own copy
+    # in the persistent HOME, so an in-IDE update still wins over the baked one.
+    system_install = pathlib.Path("/etc/rstudio/pai/bin")
+    user_install = pathlib.Path.home() / ".local/share/rstudio/pai/bin"
+    if not (user_install / "dist/server/main.js").exists() \
+            and (system_install / "dist/server/main.js").exists():
+        os.environ.setdefault("RSTUDIO_POSIT_AI_PATH", str(system_install))
+
     # Model choice is not env-configurable in the shipping assistant build, so
     # seed the user's settings file on first launch (same pattern as opencode).
     # It lives in the persistent HOME, so later edits in the UI stick; delete it

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -51,7 +51,7 @@ export OPENCODE_CONFIG="${HOME}/.config/opencode/opencode.json"
 EOF
 chmod 0644 /etc/profile.d/opencode.sh
 
-# Roo Cline pre-configuration via Jupyter server startup hook.
+# Roo Cline (and Posit Assistant) pre-configuration via Jupyter server startup hook.
 # /etc/jupyter/ is in Jupyter's config search path (outside $HOME, survives JupyterHub mounts).
 # This script runs when the Jupyter server starts — before users access code-server.
 # It generates a Roo settings import file with OPENAI_API_KEY from the environment,
@@ -60,7 +60,7 @@ chmod 0644 /etc/profile.d/opencode.sh
 # and API key are configured automatically each session.
 mkdir -p /etc/jupyter
 cat > /etc/jupyter/jupyter_server_config.py <<'PYEOF'
-"""Jupyter server startup hook: seed per-user opencode config and Roo Cline settings."""
+"""Jupyter server startup hook: seed per-user opencode, Roo Cline and Posit Assistant settings."""
 import os, json, pathlib, logging, shutil
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,34 @@ def _setup_roo_cline():
     existing["roo-cline.autoImportSettingsPath"] = str(settings_file)
     cs_settings_file.write_text(json.dumps(existing, indent=2))
 
+def _setup_posit_assistant():
+    # Posit Assistant (the AI pane in RStudio) is baked into the image by
+    # install_posit_assistant.sh; this only points it at the NRP endpoint.
+    #
+    # Provider credentials come from the environment: the assistant reads
+    # OPENAI_COMPATIBLE_{BASE_URL,API_KEY} for its "OpenAI Compatible" provider,
+    # and env vars outrank both ~/.posit/ai/providers.json and the settings UI.
+    # rserver is spawned by jupyter-rsession-proxy as a child of this process,
+    # so setting them here is enough for the rsession that hosts the assistant.
+    os.environ.setdefault("OPENAI_COMPATIBLE_BASE_URL", "https://ellm.nrp-nautilus.io/v1")
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if api_key:
+        os.environ.setdefault("OPENAI_COMPATIBLE_API_KEY", api_key)
+
+    # Model choice is not env-configurable in the shipping assistant build, so
+    # seed the user's settings file on first launch (same pattern as opencode).
+    # It lives in the persistent HOME, so later edits in the UI stick; delete it
+    # and restart the container to go back to the defaults below.
+    settings_file = pathlib.Path.home() / ".posit/assistant/settings.json"
+    if not settings_file.exists():
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(json.dumps({
+            "model": {
+                "provider": "openai-compatible",
+                "id": "qwen3"
+            }
+        }, indent=2))
+
 try:
     _setup_opencode()
 except Exception as e:
@@ -114,4 +142,9 @@ try:
     _setup_roo_cline()
 except Exception as e:
     logger.error(f"Roo Cline setup failed: {e}")
+
+try:
+    _setup_posit_assistant()
+except Exception as e:
+    logger.error(f"Posit Assistant setup failed: {e}")
 PYEOF

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -107,31 +107,51 @@ def _setup_roo_cline():
 
 def _setup_posit_assistant():
     # Posit Assistant (the AI pane in RStudio) is baked into the image by
-    # install_posit_assistant.sh; this only points it at the NRP endpoint.
+    # install_posit_assistant.sh, which also writes a managed block into R's
+    # Renviron.site with the install path and the provider base URL.
     #
-    # Provider credentials come from the environment: the assistant reads
-    # OPENAI_COMPATIBLE_{BASE_URL,API_KEY} for its "OpenAI Compatible" provider,
-    # and env vars outrank both ~/.posit/ai/providers.json and the settings UI.
-    # rserver is spawned by jupyter-rsession-proxy as a child of this process,
-    # so setting them here is enough for the rsession that hosts the assistant.
-    os.environ.setdefault("OPENAI_COMPATIBLE_BASE_URL", "https://ellm.nrp-nautilus.io/v1")
+    # Why Renviron.site and not the environment: rserver hands rsession a
+    # curated ~27-variable environment and drops everything else, so nothing
+    # exported here ever reaches the RStudio session. R reads Renviron.site at
+    # startup and putenv()s it into the rsession process, which the assistant's
+    # Node backend inherits. Only the API key is missing from that block,
+    # because it is a runtime secret -- fill it in now.
+    #
+    # Rewriting the whole block (rather than appending) keeps it idempotent
+    # across restarts and means a rotated key never lingers.
+    renviron = pathlib.Path(os.environ.get("R_HOME", "/usr/lib/R")) / "etc/Renviron.site"
+    begin, end = "# >>> rocker-ml posit-assistant >>>", "# <<< rocker-ml posit-assistant <<<"
     api_key = os.environ.get("OPENAI_API_KEY", "")
-    if api_key:
-        os.environ.setdefault("OPENAI_COMPATIBLE_API_KEY", api_key)
 
-    # RStudio finds the image-baked bundle at /etc/rstudio/pai/bin only when it
-    # resolves systemConfigDir() to /etc/rstudio. jupyter-rsession-proxy sets
-    # RSTUDIO_CONFIG_DIR to a fresh mkdtemp() for every rserver it spawns, and
-    # that variable short-circuits the whole XDG lookup -- so RStudio searches
-    # <tmpdir>/pai/bin, finds nothing, and offers to download the assistant.
-    # Point RSTUDIO_POSIT_AI_PATH (the first entry in RStudio's search order) at
-    # the real location instead. Skipped when the user already has their own copy
-    # in the persistent HOME, so an in-IDE update still wins over the baked one.
+    # An assistant the user updated from inside RStudio lives in the persistent
+    # HOME and must win; RSTUDIO_POSIT_AI_PATH would otherwise shadow it.
     system_install = pathlib.Path("/etc/rstudio/pai/bin")
     user_install = pathlib.Path.home() / ".local/share/rstudio/pai/bin"
-    if not (user_install / "dist/server/main.js").exists() \
-            and (system_install / "dist/server/main.js").exists():
-        os.environ.setdefault("RSTUDIO_POSIT_AI_PATH", str(system_install))
+    use_system = ((system_install / "dist/server/main.js").exists()
+                  and not (user_install / "dist/server/main.js").exists())
+
+    lines = [begin, "# Managed by install_posit_assistant.sh and the Jupyter startup hook."]
+    if use_system:
+        lines.append(f"RSTUDIO_POSIT_AI_PATH={system_install}")
+    lines.append("OPENAI_COMPATIBLE_BASE_URL=https://ellm.nrp-nautilus.io/v1")
+    if api_key:
+        lines.append(f"OPENAI_COMPATIBLE_API_KEY={api_key}")
+    lines.append(end)
+
+    try:
+        existing = renviron.read_text() if renviron.exists() else ""
+    except Exception:
+        existing = ""
+    if begin in existing and end in existing:
+        head, rest = existing.split(begin, 1)
+        existing = head + rest.split(end, 1)[1]
+    renviron.write_text(existing.rstrip("\n") + "\n\n" + "\n".join(lines) + "\n")
+
+    # Also export into this process, so terminals and any non-rsession consumer
+    # (the `pa` CLI, code-server terminals) see the same provider config.
+    os.environ.setdefault("OPENAI_COMPATIBLE_BASE_URL", "https://ellm.nrp-nautilus.io/v1")
+    if api_key:
+        os.environ.setdefault("OPENAI_COMPATIBLE_API_KEY", api_key)
 
     # Model choice is not env-configurable in the shipping assistant build, so
     # seed the user's settings file on first launch (same pattern as opencode).
@@ -146,6 +166,7 @@ def _setup_posit_assistant():
                 "id": "qwen3"
             }
         }, indent=2))
+
 
 try:
     _setup_opencode()

--- a/install_posit_assistant.sh
+++ b/install_posit_assistant.sh
@@ -57,3 +57,34 @@ done
 
 # World-readable, root-owned: every user reads the same copy, nobody mutates it.
 chmod -R a+rX "$INSTALL_DIR"
+
+# Getting environment variables into the RStudio session is the hard part.
+# rserver does NOT pass its own environment to rsession: it builds a curated
+# ~27-variable environment (RS_*/RSTUDIO_*/R_* plus HOME/PATH/USER/LANG/SHELL/
+# LD_LIBRARY_PATH/XDG_CONFIG_HOME) and drops everything else, so anything
+# exported by the Jupyter server -- including RSTUDIO_POSIT_AI_PATH and the
+# provider credentials -- never arrives. /etc/rstudio/env-vars does not help
+# either; rserver only setenv()s that into its own process.
+#
+# R's Renviron.site is the way through: R putenv()s it into the rsession
+# process at startup, before the assistant is ever looked up, and the Node
+# backend inherits it (SessionChat launches the backend with the full process
+# environment, and RStudio's own source cites ~/.Renviron as how proxy vars
+# reach it). This is the same reason set_renviron.sh exists in this repo.
+#
+# The file is chowned to the container user so the Jupyter startup hook can
+# refresh the block with the runtime API key, which must not be baked in.
+# Keeping it here rather than in ~/.Renviron means the key lives on the
+# container filesystem and is regenerated every start, instead of persisting
+# in the JupyterHub home volume after it is rotated.
+RENVIRON_SITE="$(R RHOME)/etc/Renviron.site"
+touch "$RENVIRON_SITE"
+cat >> "$RENVIRON_SITE" <<EOF
+
+# >>> rocker-ml posit-assistant >>>
+# Managed by install_posit_assistant.sh and the Jupyter startup hook.
+RSTUDIO_POSIT_AI_PATH=${INSTALL_DIR}
+OPENAI_COMPATIBLE_BASE_URL=https://ellm.nrp-nautilus.io/v1
+# <<< rocker-ml posit-assistant <<<
+EOF
+chown "${NB_USER:-jovyan}" "$RENVIRON_SITE"

--- a/install_posit_assistant.sh
+++ b/install_posit_assistant.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# Posit Assistant (the AI pane in RStudio 2026.04.0+) is not shipped inside the
+# rstudio-server deb: RStudio downloads a Node bundle on first use into
+# ~/.local/share/rstudio/pai/bin. That is a per-user, network-dependent step, so
+# instead we bake the bundle into the image at the system-wide location RStudio
+# searches next: /etc/rstudio/pai/bin (xdg systemConfigDir + "pai/bin").
+#
+# Lookup order in RStudio (ChatInstallation.cpp locatePositAssistantInstallation):
+#   1. $RSTUDIO_POSIT_AI_PATH   2. ~/.local/share/rstudio/pai/bin   3. /etc/rstudio/pai/bin
+# Using (3) rather than the env var deliberately leaves (2) available: if a user
+# lets RStudio update the assistant, the newer copy in their persistent HOME
+# wins over the image-baked one instead of being shadowed.
+
+MANIFEST_URL="https://cdn.posit.co/posit-ai/manifest.json"
+INSTALL_DIR="/etc/rstudio/pai/bin"
+
+apt-get update && apt-get -y install unzip
+rm -rf /var/lib/apt/lists/*
+
+# The manifest keys releases by wire-protocol version ("9.0", "10.0", "11.0", ...).
+# Take the highest, matching the current stable RStudio we install alongside it.
+# If a future RStudio ever speaks an older protocol than the newest published
+# bundle, this degrades gracefully -- RStudio reports the mismatch and offers to
+# install the right version into the user's HOME.
+read -r PAI_VERSION PAI_URL PAI_SHA256 <<EOF
+$(curl -fsSL "$MANIFEST_URL" | python3 -c '
+import json, sys
+m = json.load(sys.stdin)["versions"]
+p = max(m, key=lambda k: tuple(int(n) for n in k.split(".")))
+v = m[p]
+print(v["version"], v["url"], v["sha256"])
+')
+EOF
+
+if [ -z "$PAI_URL" ]; then
+    echo "ERROR: could not resolve a Posit Assistant build from ${MANIFEST_URL}" >&2
+    exit 1
+fi
+echo "Installing Posit Assistant ${PAI_VERSION} to ${INSTALL_DIR}"
+
+curl -fsSL "$PAI_URL" -o /tmp/pai.zip
+echo "${PAI_SHA256}  /tmp/pai.zip" | sha256sum -c -
+
+mkdir -p "$INSTALL_DIR"
+unzip -q /tmp/pai.zip -d "$INSTALL_DIR"
+rm -f /tmp/pai.zip
+
+# RStudio only treats the directory as a valid install when all three exist.
+for f in dist/server/main.js dist/client/index.html package.json; do
+    if [ ! -e "${INSTALL_DIR}/${f}" ]; then
+        echo "ERROR: Posit Assistant bundle is missing ${f}" >&2
+        exit 1
+    fi
+done
+
+# World-readable, root-owned: every user reads the same copy, nobody mutates it.
+chmod -R a+rX "$INSTALL_DIR"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -42,6 +42,36 @@ check "posit assistant bundle" "
     test -f /etc/rstudio/pai/bin/package.json"
 check "posit assistant readable by user" "head -c1 /etc/rstudio/pai/bin/dist/server/main.js >/dev/null"
 
+# The bundle being on disk is not enough: RStudio has to resolve it. Emulate
+# locatePositAssistantInstallation() under the environment jupyter-rsession-proxy
+# actually gives rserver -- it sets RSTUDIO_CONFIG_DIR to a fresh mkdtemp(),
+# which short-circuits the /etc/rstudio lookup. This is the check that would
+# have caught the assistant silently not being found on JupyterHub.
+check "posit assistant resolves under rsession-proxy env" "
+    export RSTUDIO_CONFIG_DIR=\\$(mktemp -d)
+    python3 - <<'EOF'
+import os, pathlib, runpy, sys
+runpy.run_path('/etc/jupyter/jupyter_server_config.py')
+
+def valid(p):
+    p = pathlib.Path(p)
+    return ((p / 'dist/server/main.js').exists()
+            and (p / 'dist/client/index.html').exists())
+
+# RStudio's search order, in order.
+candidates = []
+if os.environ.get('RSTUDIO_POSIT_AI_PATH'):
+    candidates.append(os.environ['RSTUDIO_POSIT_AI_PATH'])
+candidates.append(str(pathlib.Path.home() / '.local/share/rstudio/pai/bin'))
+# systemConfigDir(): RSTUDIO_CONFIG_DIR short-circuits it, else XDG_CONFIG_DIRS, else /etc.
+sysdir = os.environ.get('RSTUDIO_CONFIG_DIR')
+candidates.append(f'{sysdir}/pai/bin' if sysdir else '/etc/rstudio/pai/bin')
+
+found = next((c for c in candidates if valid(c)), None)
+assert found, f'RStudio would find no assistant install; searched {candidates}'
+print('resolves to', found, file=sys.stderr)
+EOF"
+
 # Execute the Jupyter startup hook the way the server would, then assert it
 # produced the per-user config and the provider environment.
 check "startup hook configures AI tools" "

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -5,19 +5,31 @@
 #
 # Usage: bash smoke-test.sh [IMAGE]     (default: rocker-ml:local, as built by run.sh)
 
-set -euo pipefail
+set -uo pipefail
 
 IMAGE="${1:-rocker-ml:local}"
 echo "Smoke-testing ${IMAGE}"
 
-run() {
-    docker run --rm --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" bash -lc "$1"
-}
-
 fail=0
+
+# One-liner check: runs in a login shell inside the image.
 check() {
     local name="$1"; shift
-    if run "$*" >/tmp/smoke.out 2>&1; then
+    if docker run --rm --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" \
+            bash -lc "$*" >/tmp/smoke.out 2>&1; then
+        echo "ok    ${name}"
+    else
+        echo "FAIL  ${name}"
+        sed 's/^/      | /' /tmp/smoke.out
+        fail=1
+    fi
+}
+
+# Script check: reads the script from stdin, so it can contain any quoting.
+check_script() {
+    local name="$1"
+    if docker run --rm -i --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" \
+            bash -s >/tmp/smoke.out 2>&1; then
         echo "ok    ${name}"
     else
         echo "FAIL  ${name}"
@@ -42,50 +54,70 @@ check "posit assistant bundle" "
     test -f /etc/rstudio/pai/bin/package.json"
 check "posit assistant readable by user" "head -c1 /etc/rstudio/pai/bin/dist/server/main.js >/dev/null"
 
-# The bundle being on disk is not enough: RStudio has to resolve it. Emulate
-# locatePositAssistantInstallation() under the environment jupyter-rsession-proxy
-# actually gives rserver -- it sets RSTUDIO_CONFIG_DIR to a fresh mkdtemp(),
-# which short-circuits the /etc/rstudio lookup. This is the check that would
-# have caught the assistant silently not being found on JupyterHub.
-check "posit assistant resolves under rsession-proxy env" "
-    export RSTUDIO_CONFIG_DIR=\\$(mktemp -d)
-    python3 - <<'EOF'
-import os, pathlib, runpy, sys
-runpy.run_path('/etc/jupyter/jupyter_server_config.py')
+# The bundle being on disk is not enough, and neither is exporting variables
+# from the Jupyter server: rserver hands rsession a curated ~27-variable
+# environment and drops everything else. R's Renviron.site is what actually
+# gets through. Run the startup hook, then read the variables back from an R
+# process started with a DELIBERATELY EMPTY environment -- if they show up
+# there, they came from Renviron.site, which is exactly how rsession and the
+# assistant's Node backend will get them.
+check_script "assistant config reaches an rsession-like environment" <<'SCRIPT'
+set -e
+python3 -c 'import runpy; runpy.run_path("/etc/jupyter/jupyter_server_config.py")'
+
+# Mimic what rserver gives a session: none of the Jupyter environment, plus the
+# temp RSTUDIO_CONFIG_DIR the rsession-proxy sets (which breaks the /etc lookup).
+env -i HOME="$HOME" PATH=/usr/local/bin:/usr/bin:/bin LANG=C \
+    RSTUDIO_CONFIG_DIR="$(mktemp -d)" \
+    R -q -s -e 'cat(Sys.getenv("RSTUDIO_POSIT_AI_PATH"), Sys.getenv("OPENAI_COMPATIBLE_API_KEY"), Sys.getenv("OPENAI_COMPATIBLE_BASE_URL"), Sys.getenv("RSTUDIO_CONFIG_DIR"), sep="\n")' \
+    > /tmp/rsession-env
+
+python3 - <<'PY'
+import pathlib
+path, key, url, cfgdir = pathlib.Path('/tmp/rsession-env').read_text().splitlines()
 
 def valid(p):
     p = pathlib.Path(p)
-    return ((p / 'dist/server/main.js').exists()
-            and (p / 'dist/client/index.html').exists())
+    return (p / 'dist/server/main.js').exists() and (p / 'dist/client/index.html').exists()
 
-# RStudio's search order, in order.
-candidates = []
-if os.environ.get('RSTUDIO_POSIT_AI_PATH'):
-    candidates.append(os.environ['RSTUDIO_POSIT_AI_PATH'])
-candidates.append(str(pathlib.Path.home() / '.local/share/rstudio/pai/bin'))
-# systemConfigDir(): RSTUDIO_CONFIG_DIR short-circuits it, else XDG_CONFIG_DIRS, else /etc.
-sysdir = os.environ.get('RSTUDIO_CONFIG_DIR')
-candidates.append(f'{sysdir}/pai/bin' if sysdir else '/etc/rstudio/pai/bin')
+# RStudio's search order (ChatInstallation.cpp locatePositAssistantInstallation).
+candidates = [c for c in (
+    path,
+    str(pathlib.Path.home() / '.local/share/rstudio/pai/bin'),
+    f'{cfgdir}/pai/bin' if cfgdir else '/etc/rstudio/pai/bin',
+) if c]
 
 found = next((c for c in candidates if valid(c)), None)
 assert found, f'RStudio would find no assistant install; searched {candidates}'
-print('resolves to', found, file=sys.stderr)
-EOF"
+assert key == 'smoke-test-key', f'provider API key did not reach the session: {key!r}'
+assert url.startswith('https://'), f'provider base URL did not reach the session: {url!r}'
+print(f'resolves to {found}, credentials present')
+PY
+SCRIPT
 
-# Execute the Jupyter startup hook the way the server would, then assert it
-# produced the per-user config and the provider environment.
-check "startup hook configures AI tools" "
-    python3 - <<'EOF'
-import os, json, pathlib, runpy, sys
+# The hook is also responsible for the per-user config files.
+check_script "startup hook seeds per-user AI config" <<'SCRIPT'
+set -e
+python3 - <<'PY'
+import json, pathlib, runpy
 runpy.run_path('/etc/jupyter/jupyter_server_config.py')
 home = pathlib.Path.home()
 assert (home / '.config/opencode/opencode.json').exists(), 'opencode config not seeded'
 s = json.loads((home / '.posit/assistant/settings.json').read_text())
 assert s['model']['provider'] == 'openai-compatible', s
-assert os.environ['OPENAI_COMPATIBLE_API_KEY'] == 'smoke-test-key'
-assert os.environ['OPENAI_COMPATIBLE_BASE_URL'].startswith('https://'), os.environ['OPENAI_COMPATIBLE_BASE_URL']
 assert json.loads(pathlib.Path('/tmp/roo-cline/nrp-settings.json').read_text())
-EOF"
+PY
+SCRIPT
+
+# Running the hook twice must not duplicate the managed Renviron block.
+check_script "startup hook is idempotent" <<'SCRIPT'
+set -e
+for _ in 1 2 3; do
+    python3 -c 'import runpy; runpy.run_path("/etc/jupyter/jupyter_server_config.py")'
+done
+n=$(grep -c '>>> rocker-ml posit-assistant >>>' /usr/lib/R/etc/Renviron.site)
+test "$n" -eq 1 || { echo "managed block appears $n times"; exit 1; }
+SCRIPT
 
 if [ "$fail" -ne 0 ]; then
     echo "smoke test FAILED"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Smoke-test a built image. Checks that the pieces the Dockerfiles install are
+# actually present and wired up -- not a substitute for opening the IDEs by
+# hand, but enough to catch a silently broken layer.
+#
+# Usage: bash smoke-test.sh [IMAGE]     (default: rocker-ml:local, as built by run.sh)
+
+set -euo pipefail
+
+IMAGE="${1:-rocker-ml:local}"
+echo "Smoke-testing ${IMAGE}"
+
+run() {
+    docker run --rm --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" bash -lc "$1"
+}
+
+fail=0
+check() {
+    local name="$1"; shift
+    if run "$*" >/tmp/smoke.out 2>&1; then
+        echo "ok    ${name}"
+    else
+        echo "FAIL  ${name}"
+        sed 's/^/      | /' /tmp/smoke.out
+        fail=1
+    fi
+}
+
+check "R runs"                  "R --version"
+check "python venv is default"  "test \"\$(command -v python3)\" = /opt/venv/bin/python3"
+check "jupyter runs"            "jupyter --version"
+check "RStudio server installed" "test -x /usr/lib/rstudio-server/bin/rserver"
+check "quarto on PATH"          "command -v quarto"
+check "opencode installed"      "command -v opencode"
+check "code-server extensions"  "ls /opt/share/code-server | grep -qi kilocode"
+
+# Posit Assistant: RStudio only treats the directory as an install when all
+# three of these exist (ChatInstallation.cpp verifyPositAiInstallation).
+check "posit assistant bundle" "
+    test -f /etc/rstudio/pai/bin/dist/server/main.js &&
+    test -f /etc/rstudio/pai/bin/dist/client/index.html &&
+    test -f /etc/rstudio/pai/bin/package.json"
+check "posit assistant readable by user" "head -c1 /etc/rstudio/pai/bin/dist/server/main.js >/dev/null"
+
+# Execute the Jupyter startup hook the way the server would, then assert it
+# produced the per-user config and the provider environment.
+check "startup hook configures AI tools" "
+    python3 - <<'EOF'
+import os, json, pathlib, runpy, sys
+runpy.run_path('/etc/jupyter/jupyter_server_config.py')
+home = pathlib.Path.home()
+assert (home / '.config/opencode/opencode.json').exists(), 'opencode config not seeded'
+s = json.loads((home / '.posit/assistant/settings.json').read_text())
+assert s['model']['provider'] == 'openai-compatible', s
+assert os.environ['OPENAI_COMPATIBLE_API_KEY'] == 'smoke-test-key'
+assert os.environ['OPENAI_COMPATIBLE_BASE_URL'].startswith('https://'), os.environ['OPENAI_COMPATIBLE_BASE_URL']
+assert json.loads(pathlib.Path('/tmp/roo-cline/nrp-settings.json').read_text())
+EOF"
+
+if [ "$fail" -ne 0 ]; then
+    echo "smoke test FAILED"
+    exit 1
+fi
+echo "smoke test passed"


### PR DESCRIPTION
RStudio 2026.04+ ships the AI pane but not the assistant itself: on first use it downloads a Node bundle from `cdn.posit.co` into `~/.local/share/rstudio/pai/bin`. This bakes the bundle in at build time instead.

## Posit Assistant

- `install_posit_assistant.sh` resolves version + SHA256 from `https://cdn.posit.co/posit-ai/manifest.json` (keyed by wire-protocol version; takes the highest — nothing pinned), verifies the checksum, and extracts to **`/etc/rstudio/pai/bin`**, the system-wide path in RStudio's lookup order (`ChatInstallation.cpp:locatePositAssistantInstallation`).
- Deliberately *not* `RSTUDIO_POSIT_AI_PATH`: that shadows the user-level path, so a user who let RStudio update the assistant would keep getting the image-baked copy. With the system path, an updated copy in the persistent HOME wins.
- `_setup_posit_assistant()` in the existing Jupyter startup hook exports `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` (env vars outrank both `~/.posit/ai/providers.json` and the settings UI), and seeds `~/.posit/assistant/settings.json` with the model on first launch — model choice is not env-configurable in the shipping bundle. Same seed-into-HOME pattern as opencode, so user edits persist.
- No `rstudio-prefs.json` change needed: the `assistant` and `chat_provider` prefs already default to `posit`.

## Pre-merge builds

The base images had no PR build path — the release workflows only run on push to `master`, and their merge job writes `:latest`, so this change would otherwise get its first real build from the run that publishes it.

- `build-pr.yml` builds amd64-only images on PRs and pushes `ghcr.io/rocker-org/{ml,cuda}:pr-<number>`. Never writes `latest`; skips fork PRs (read-only `GITHUB_TOKEN`).
- `smoke-test.sh` runs in that job and locally against any tag. Checks R/venv/Jupyter/rserver/quarto/opencode/extensions, the assistant bundle at the three paths RStudio validates, and executes the startup hook to assert it seeds the opencode, Roo and assistant config.

## Not verified

Whether the pane goes straight to a usable chat with BYOK env credentials or still shows a "Sign in to Posit AI" gate first, and whether the highest manifest protocol matches what current stable RStudio speaks. A mismatch degrades gracefully (RStudio offers a user-level install) but would defeat the pre-install. Both need the built image opened by hand — which is what the PR tag is for.