### PR TITLE
Persist Kilo Code config in $HOME

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,29 +177,41 @@ The relevant RStudio prefs (`assistant`, `chat_provider`) already default to `po
 `/etc/rstudio/rstudio-prefs.json` entry is needed. `RSTUDIO_DISABLE_POSIT_ASSISTANT` is the
 off switch if one is ever wanted.
 
-## Roo Cline Configuration
+## Kilo Code Configuration
 
-Roo Cline stores its API provider config in VS Code **secret storage**, which falls back to
-in-memory on Linux (no libsecret). This means secrets reset on every code-server restart.
+Kilo Code v7 is an opencode fork. Its `data`, `state` and `cache` directories are
+HOME-resident (`~/.local/share/kilo`, `~/.local/state/kilo`, `~/.cache/kilo`) and so persist
+on the JupyterHub home volume, but its **config** directory is `$XDG_CONFIG_HOME/kilo` — and
+this image points `XDG_CONFIG_HOME` at `/opt/share/xdg-config`, which lives in the image, not
+the volume. Everything Kilo writes there (custom providers and models added from the UI,
+agents, MCP servers, all of `kilo.json`) was therefore discarded on every restart.
 
-To work around this, `/etc/jupyter/jupyter_server_config.py` is installed at build time.
-This hook runs when the Jupyter server starts (before the user accesses code-server) and:
+`install_llms.sh` replaces that directory with a symlink:
 
-1. Reads `OPENAI_API_KEY` from the environment
-2. Writes a Roo settings import file to `/tmp/roo-cline/nrp-settings.json`
-3. Sets `roo-cline.autoImportSettingsPath` in `~/.local/share/code-server/User/settings.json`
+    /opt/share/xdg-config/kilo -> /home/jovyan/.config/kilo
 
-Roo re-reads `autoImportSettingsPath` on every extension activation and re-imports the NRP
-provider config (including API key) automatically each session.
+so the extension reads and writes the persistent HOME without knowing anything about it.
+`kilo debug paths` still prints the `/opt/share` path; it resolves into HOME.
 
-`/etc/jupyter/` is in Jupyter's config search path and is outside `$HOME`, so it persists
-across JupyterHub volume mounts. The generated `/tmp/roo-cline/nrp-settings.json` lives only
-for the duration of the container session (correct: it gets regenerated each time with the
-current `OPENAI_API_KEY`).
+The sysadmin template lives at `/opt/share/kilo-template/kilo.json` (outside `$HOME`, since a
+build-time write to `$HOME` is shadowed by the volume mount). The Jupyter startup hook
+`/etc/jupyter/jupyter_server_config.py`:
 
-The `~/.local/share/code-server/User/settings.json` entry persists in the user's home
-volume once written, so new users get it on first Jupyter start and it stays for subsequent
-sessions.
+1. Re-asserts the symlink — repairing a container whose `/opt/share` predates this change,
+   and moving anything already written to the ephemeral location into HOME first
+2. Copies the template to `~/.config/kilo/kilo.json` if that file does not exist
+
+The template uses the same `{env:OPENAI_API_KEY}` syntax as the opencode config (Kilo reads
+the opencode config format verbatim, including `opencode.json` as a legacy global filename),
+so the key is expanded at read time and never written to disk. Delete
+`~/.config/kilo/kilo.json` and restart to re-seed from the current template.
+
+`/etc/jupyter/` is in Jupyter's config search path and outside `$HOME`, so the hook itself
+survives JupyterHub volume mounts.
+
+Note the earlier Roo Cline wiring (`roo-cline.autoImportSettingsPath` into the code-server
+`settings.json`) has been removed: the installed extension is `kilocode.kilo-code`, and the v7
+rewrite contributes only `kilo-code.new.*` settings — it never read the Roo keys.
 
 ## Testing a change before merging
 
@@ -212,7 +224,7 @@ lines for hand-testing.
 
 `smoke-test.sh` also runs locally against any tag (`bash smoke-test.sh rocker-ml:local`,
 pairing with `run.sh`). It asserts R/Python/Jupyter/RStudio/quarto/opencode are present and
-that the Jupyter startup hook actually seeds the opencode, Roo and Posit Assistant config
+that the Jupyter startup hook actually seeds the opencode, Kilo Code and Posit Assistant config
 when executed with an `OPENAI_API_KEY` in the environment. It does **not** cover anything
 GPU (no GPU runners) or anything that needs a browser — the IDE panes still need a human.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To access a stable build, users may refer to specific SHA hash tags on the [GitH
 ## Features
 
 - **IDEs:** Jupyter Lab, RStudio Server, VSCode (code-server) with common extensions
-- **AI Coding Assistants:** [opencode](https://opencode.ai) CLI and VSCode extension, [Roo Cline](https://github.com/RooVeterinaryInc/roo-cline) VSCode extension, [Posit Assistant](https://assistant.posit.co) in RStudio
+- **AI Coding Assistants:** [opencode](https://opencode.ai) CLI and VSCode extension, [Kilo Code](https://kilocode.ai) VSCode extension, [Posit Assistant](https://assistant.posit.co) in RStudio
 - **ML Plugins:** Tensorboard support
 - **Python:** 3.12 with pip-based environment at `/opt/venv` (user-writable)
 - **CUDA Support:** CUDA 13 runtime libraries (GPU image only)
@@ -106,13 +106,16 @@ Additional utilities and VSCode extensions are installed in `/opt/share` (via `X
 
 ### AI Coding Assistants
 
-[opencode](https://opencode.ai) (CLI + VSCode extension) and [Roo Cline](https://github.com/RooVeterinaryInc/roo-cline) (VSCode extension) are pre-installed and pre-configured for the NRP Nautilus LLM endpoint.
+[opencode](https://opencode.ai) (CLI + VSCode extension) and [Kilo Code](https://kilocode.ai) (VSCode extension) are pre-installed and pre-configured for the NRP Nautilus LLM endpoint.
 
 **opencode** has two providers enabled out of the box:
 - **NRP**: default provider, requires `OPENAI_API_KEY` injected via JupyterHub helm chart
 - **GitHub Copilot**: available to any user with a Copilot subscription — run `/connect` in opencode to authenticate via device flow (one-time per user; token persists in home volume)
 
-**Roo Cline** is configured automatically at Jupyter server start via a startup hook that reads `OPENAI_API_KEY` from the environment.
+**Kilo Code** is seeded with the same NRP provider at Jupyter server start. Its config lives at
+`~/.config/kilo/kilo.json` — on the persistent home volume, reached through a
+`$XDG_CONFIG_HOME/kilo` symlink — so any model or provider a user adds from the Kilo UI
+survives a restart. Delete that file and restart to go back to the image defaults.
 
 **Posit Assistant** (the AI pane in RStudio) is baked into the image at `/etc/rstudio/pai/bin`,
 so users are not prompted to download it on first use. Its install path and the NRP provider

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -51,16 +51,59 @@ export OPENCODE_CONFIG="${HOME}/.config/opencode/opencode.json"
 EOF
 chmod 0644 /etc/profile.d/opencode.sh
 
-# Roo Cline (and Posit Assistant) pre-configuration via Jupyter server startup hook.
+# Kilo Code (VS Code extension) config persistence.
+#
+# Kilo v7 is an opencode fork: its data/, state/ and cache/ dirs are HOME-resident
+# (~/.local/share/kilo, ~/.local/state/kilo, ~/.cache/kilo -- all persistent on
+# JupyterHub), but its *config* dir is $XDG_CONFIG_HOME/kilo, and this image points
+# XDG_CONFIG_HOME at /opt/share/xdg-config, which is image-resident and therefore
+# thrown away on every restart. Anything a user configures in the Kilo UI that lands
+# in kilo.json -- custom providers, custom models, agents, MCP servers -- was lost.
+#
+# Fix: replace $XDG_CONFIG_HOME/kilo with a symlink into the persistent HOME, so the
+# extension reads and writes ~/.config/kilo without knowing anything about it. The
+# sysadmin template stays outside HOME (a build-time write to $HOME is shadowed by
+# the JupyterHub volume mount) and is copied in on first launch by the startup hook.
+mkdir -p /opt/share/kilo-template
+cat > /opt/share/kilo-template/kilo.json <<'EOF'
+{
+  "model": "nrp/qwen3",
+  "provider": {
+    "nrp": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "NRP",
+      "options": {
+        "baseURL": "https://ellm.nrp-nautilus.io/v1",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "qwen3": {
+          "name": "Qwen3"
+        },
+        "minimax-m2": {
+          "name": "MiniMax M2"
+        }
+      }
+    },
+    "copilot": {}
+  }
+}
+EOF
+rm -rf ${XDG_CONFIG_HOME}/kilo
+ln -s /home/${NB_USER:-jovyan}/.config/kilo ${XDG_CONFIG_HOME}/kilo
+chown -h ${NB_USER:-jovyan}:users ${XDG_CONFIG_HOME}/kilo
+chown -R ${NB_USER:-jovyan}:users /opt/share/kilo-template
+
+# Kilo Code (and Posit Assistant) pre-configuration via Jupyter server startup hook.
 # /etc/jupyter/ is in Jupyter's config search path (outside $HOME, survives JupyterHub mounts).
 # This script runs when the Jupyter server starts — before users access code-server.
-# It generates a Roo settings import file with OPENAI_API_KEY from the environment,
-# then sets roo-cline.autoImportSettingsPath in the code-server user settings.json.
-# Roo re-reads autoImportSettingsPath on every extension activation, so the NRP provider
-# and API key are configured automatically each session.
+# It repairs the $XDG_CONFIG_HOME/kilo -> ~/.config/kilo symlink and seeds the user's
+# kilo.json from the image-baked template on first launch. The API key is not written
+# into the file: {env:OPENAI_API_KEY} is resolved by Kilo at read time from the
+# environment the extension host inherits.
 mkdir -p /etc/jupyter
 cat > /etc/jupyter/jupyter_server_config.py <<'PYEOF'
-"""Jupyter server startup hook: seed per-user opencode, Roo Cline and Posit Assistant settings."""
+"""Jupyter server startup hook: seed per-user opencode, Kilo Code and Posit Assistant settings."""
 import os, json, pathlib, logging, shutil
 logger = logging.getLogger(__name__)
 
@@ -75,35 +118,39 @@ def _setup_opencode():
         shutil.copyfile(template, user_config)
     os.environ.setdefault("OPENCODE_CONFIG", str(user_config))
 
-def _setup_roo_cline():
-    api_key = os.environ.get("OPENAI_API_KEY", "")
-    settings_dir = pathlib.Path("/tmp/roo-cline")
-    settings_dir.mkdir(exist_ok=True)
-    settings_file = settings_dir / "nrp-settings.json"
-    settings_file.write_text(json.dumps({
-        "providerProfiles": {
-            "currentApiConfigName": "NRP",
-            "apiConfigs": {
-                "NRP": {
-                    "apiProvider": "openai",
-                    "openAiBaseUrl": "https://ellm.nrp-nautilus.io/v1",
-                    "openAiApiKey": api_key,
-                    "openAiModelId": "qwen3"
-                }
-            }
-        }
-    }, indent=2))
-    # Update code-server user settings.json to point Roo at the generated file.
-    # code-server user-data-dir defaults to ~/.local/share/code-server (in $HOME persistent volume).
-    cs_settings_dir = pathlib.Path.home() / ".local/share/code-server/User"
-    cs_settings_dir.mkdir(parents=True, exist_ok=True)
-    cs_settings_file = cs_settings_dir / "settings.json"
-    try:
-        existing = json.loads(cs_settings_file.read_text()) if cs_settings_file.exists() else {}
-    except Exception:
-        existing = {}
-    existing["roo-cline.autoImportSettingsPath"] = str(settings_file)
-    cs_settings_file.write_text(json.dumps(existing, indent=2))
+def _setup_kilo():
+    # Kilo reads its global config from $XDG_CONFIG_HOME/kilo, which this image points
+    # outside $HOME so that image-baked config is not shadowed by the JupyterHub volume
+    # mount -- but that also means anything Kilo *writes* there (custom providers and
+    # models added from the UI, agents, MCP servers) is discarded on restart. The build
+    # replaces that directory with a symlink to ~/.config/kilo, on the persistent HOME
+    # volume; re-assert it here so a container whose /opt/share predates this change, or
+    # in which something recreated a real directory, still ends up persistent.
+    xdg = pathlib.Path(os.environ.get("XDG_CONFIG_HOME", str(pathlib.Path.home() / ".config")))
+    link = xdg / "kilo"
+    target = pathlib.Path.home() / ".config/kilo"
+    target.mkdir(parents=True, exist_ok=True)
+    if link.resolve() != target.resolve():
+        if link.is_symlink():
+            link.unlink()
+        elif link.is_dir():
+            # Salvage anything already written into the ephemeral location.
+            for item in link.iterdir():
+                dest = target / item.name
+                if not dest.exists():
+                    shutil.move(str(item), str(dest))
+            shutil.rmtree(link)
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(target)
+
+    # Seed the NRP provider on first launch. The template uses {env:OPENAI_API_KEY},
+    # which Kilo expands at read time, so no secret is written to disk. Later edits
+    # from the Kilo UI land in this same file and now survive a restart; delete it and
+    # restart to go back to the template.
+    template = pathlib.Path("/opt/share/kilo-template/kilo.json")
+    user_config = target / "kilo.json"
+    if not user_config.exists() and template.exists():
+        shutil.copyfile(template, user_config)
 
 def _setup_posit_assistant():
     # Posit Assistant (the AI pane in RStudio) is baked into the image by
@@ -174,9 +221,9 @@ except Exception as e:
     logger.error(f"opencode setup failed: {e}")
 
 try:
-    _setup_roo_cline()
+    _setup_kilo()
 except Exception as e:
-    logger.error(f"Roo Cline setup failed: {e}")
+    logger.error(f"Kilo Code setup failed: {e}")
 
 try:
     _setup_posit_assistant()

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Fail the build at the point of failure. Without this, a transient download
+# failure in the opencode installer (a truncated tarball, an error page from the
+# CDN) leaves the RUN layer green and silently ships an image with no opencode.
+set -eo pipefail
+
 # opencode cli - installer hardcodes $HOME/.opencode/bin, so move to /usr/local/bin
 curl -fsSL https://opencode.ai/install | bash && \
   mv "${HOME}/.opencode/bin/opencode" /usr/local/bin/opencode && \

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -105,7 +105,31 @@ home = pathlib.Path.home()
 assert (home / '.config/opencode/opencode.json').exists(), 'opencode config not seeded'
 s = json.loads((home / '.posit/assistant/settings.json').read_text())
 assert s['model']['provider'] == 'openai-compatible', s
-assert json.loads(pathlib.Path('/tmp/roo-cline/nrp-settings.json').read_text())
+
+# Kilo's config dir must resolve into the persistent HOME, not $XDG_CONFIG_HOME,
+# or every custom model a user adds is lost on restart.
+import os
+link = pathlib.Path(os.environ.get('XDG_CONFIG_HOME', str(home / '.config'))) / 'kilo'
+target = home / '.config/kilo'
+assert link.resolve() == target.resolve(), f'{link} -> {link.resolve()}, expected {target}'
+k = json.loads((target / 'kilo.json').read_text())
+assert 'nrp' in k['provider'], k
+PY
+SCRIPT
+
+# A user-added model must survive the hook re-running on the next container start.
+check_script "kilo config survives a restart" <<'SCRIPT'
+set -e
+python3 - <<'PY'
+import json, pathlib, runpy
+runpy.run_path('/etc/jupyter/jupyter_server_config.py')
+cfg = pathlib.Path.home() / '.config/kilo/kilo.json'
+data = json.loads(cfg.read_text())
+data['provider']['nrp']['models']['smoke-test-model'] = {'name': 'Smoke Test'}
+cfg.write_text(json.dumps(data, indent=2))
+runpy.run_path('/etc/jupyter/jupyter_server_config.py')
+data = json.loads(cfg.read_text())
+assert 'smoke-test-model' in data['provider']['nrp']['models'], 'user edit was clobbered'
 PY
 SCRIPT
 


### PR DESCRIPTION
## Problem

Kilo Code configuration — custom providers and models added from the UI, agents, MCP servers — did not survive a container restart on JupyterHub.

Kilo v7 (`kilocode.kilo-code`) is an opencode fork. Its `data`, `state` and `cache` directories are HOME-resident and already persist; only its **config** directory is `$XDG_CONFIG_HOME/kilo`, and this image points `XDG_CONFIG_HOME` at `/opt/share/xdg-config`, which lives in the image rather than the home volume. Confirmed with `kilo debug paths` in `ghcr.io/rocker-org/ml:pr-58`:

```
data       /home/jovyan/.local/share/kilo
cache      /home/jovyan/.cache/kilo
state      /home/jovyan/.local/state/kilo
config     /opt/share/xdg-config/kilo      <- thrown away on restart
```

Separately, the existing Roo Cline wiring was dead. The installed extension is `kilocode.kilo-code`, and the v7 rewrite contributes only `kilo-code.new.*` settings, so `roo-cline.autoImportSettingsPath` configured nothing — Kilo was not actually pre-configured for NRP at all.

## Fix

- Build time: `/opt/share/xdg-config/kilo` becomes a symlink to `/home/jovyan/.config/kilo`, so the extension reads and writes the persistent HOME without knowing anything about it. `kilo debug paths` still prints the `/opt/share` path; it resolves into HOME.
- The sysadmin template moves to `/opt/share/kilo-template/kilo.json` — a build-time write to `$HOME` is shadowed by the JupyterHub volume mount.
- The Jupyter startup hook re-asserts the symlink (moving anything already written to the ephemeral location into HOME first, for containers that predate this change), then seeds `~/.config/kilo/kilo.json` **only if absent**, so a user's own edits are never clobbered.
- Replaces the dead Roo block with `_setup_kilo()`. Kilo reads the opencode config format verbatim, `{env:OPENAI_API_KEY}` included, so the same NRP template pre-configures it with no key written to disk.

## Verification

Rebuilt `Dockerfile.cpu`; full `smoke-test.sh` passes, including two new checks (config dir resolves into HOME; a user edit survives the hook re-running). Also tested against a real persistent HOME volume: a model added in session 1 is present in a fresh container in session 2, verified through `kilo debug config`. The "a real directory is already there" migration path was tested separately and correctly moves contents into HOME before re-linking.

`Dockerfile.cuda` uses the same `install_llms.sh` but was not built locally — CI covers it.