### PR TITLE
Add python3-dev to the spatial images

### DIFF
--- a/extend/Dockerfile.cpu
+++ b/extend/Dockerfile.cpu
@@ -43,6 +43,11 @@ USER root
 # GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
 # packages are needed because the Python spatial packages below are built from
 # source against them.
+# python3-dev is in that list for the same reason: SPATIAL_NO_BINARY compiles C
+# extensions, so Python.h has to be present. It used to arrive by accident as a
+# transitive dependency of an r-cran-* package in the base image; when that
+# dependency went away every spatial build started failing at shapely with
+# "fatal error: Python.h: No such file or directory". Ask for it explicitly.
 # Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
 # r-cran-* binaries, and with the lists emptied it cannot find them and silently
 # falls back to compiling every R package from source.
@@ -52,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgeos-dev \
     libproj-dev \
     proj-bin \
+    python3-dev \
     libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
 
 COPY --from=plugin-builder /plugins /tmp/plugins

--- a/extend/Dockerfile.cuda
+++ b/extend/Dockerfile.cuda
@@ -43,6 +43,11 @@ USER root
 # GDAL/GEOS/PROJ come from Ubuntu itself (26.04 ships GDAL 3.12). The -dev
 # packages are needed because the Python spatial packages below are built from
 # source against them.
+# python3-dev is in that list for the same reason: SPATIAL_NO_BINARY compiles C
+# extensions, so Python.h has to be present. It used to arrive by accident as a
+# transitive dependency of an r-cran-* package in the base image; when that
+# dependency went away every spatial build started failing at shapely with
+# "fatal error: Python.h: No such file or directory". Ask for it explicitly.
 # Do NOT delete /var/lib/apt/lists here: bspm shells out to apt to install the
 # r-cran-* binaries, and with the lists emptied it cannot find them and silently
 # falls back to compiling every R package from source.
@@ -52,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgeos-dev \
     libproj-dev \
     proj-bin \
+    python3-dev \
     libarrow2300 libparquet2300 libarrow-dataset2300 libarrow-acero2300
 
 COPY --from=plugin-builder /plugins /tmp/plugins


### PR DESCRIPTION
## Problem

Both spatial builds have failed on every run since the base published yesterday ([ML-Spatial](https://github.com/rocker-org/ml/actions/runs/33567378892), [CUDA-Spatial](https://github.com/rocker-org/ml/actions/runs/33567898801)), on both amd64 and arm64:

```
#16 6.028 src/c_api.c:11:10: fatal error: Python.h: No such file or directory
ERROR: failed to solve: process "/bin/sh -c uv pip install ... shapely ... " did not complete successfully
```

`SPATIAL_NO_BINARY` deliberately compiles shapely, fiona, rasterio, pyogrio and pyproj from source against the system GDAL/GEOS/PROJ, so the build needs Python's development headers — but nothing ever asked for them. `python3-dev` was arriving by accident as a transitive dependency of an `r-cran-*` package in the base image; that dependency went away, so the base stayed green while every spatial build started failing.

Confirmed against the published base: `ghcr.io/rocker-org/ml:latest` has no `/usr/include/python3.14/Python.h`, `apt-get install python3-dev` restores it, and the full spatial install then succeeds.

## Fix

Add `python3-dev` to the same apt list as `libgdal-dev` / `libgeos-dev` / `libproj-dev`, in both `extend/Dockerfile.cpu` and `extend/Dockerfile.cuda` — it is there for exactly the same reason.

## Verification

Built `extend/Dockerfile.cpu` locally with `--build-arg BASE=ghcr.io/rocker-org/ml:latest`, which is what CI does:

- all five source packages compile
- the "not linked against system GDAL" guard passes: `all Python bindings on system GDAL 3.12.2`
- `ogrinfo --formats` lists both the Parquet and Arrow drivers
- `smoke-test.sh` passes against the resulting image, including the new Kilo config checks from #59

This unblocks republishing `ml-spatial`, which the `nature` hub pins by digest.