### PR TITLE
Ship the AI assistants unconfigured

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,30 +95,20 @@ We use `/opt/share/` as the base for such files:
 Apps that follow the XDG Base Directory spec will read/write config here instead of
 `~/.config`, keeping their config outside the JupyterHub volume mount.
 
-**opencode** respects `XDG_CONFIG_HOME`, but `/opt/share/xdg-config/` is image-baked
-and not on the persistent HOME volume — so user edits there would not survive a
-container restart. Instead, the image ships a sysadmin **template** at
-`/opt/share/xdg-config/opencode/opencode.json`, and `OPENCODE_CONFIG` (set in
-`/etc/profile.d/opencode.sh` and in the jupyter server env) redirects opencode to
-`$HOME/.config/opencode/opencode.json`. The Jupyter server startup hook seeds the
-user copy from the template on first launch. Users edit freely and changes persist;
-delete the user copy and restart to re-seed from the current template. The API key
-is never stored in the image — `{env:OPENAI_API_KEY}` syntax makes opencode read it
-from the environment at runtime.
+**opencode and Kilo Code** respect `XDG_CONFIG_HOME`, but `/opt/share/xdg-config/` is
+image-baked and not on the persistent HOME volume — so config they write there would
+not survive a restart. Both directories are therefore symlinks into `~/.config`; see
+[AI assistant configuration](#ai-assistant-configuration).
 
-## opencode Configuration
+## opencode
 
-opencode reads `$HOME/.config/opencode/opencode.json` (via `OPENCODE_CONFIG`), seeded
-on first launch from the image template at `/opt/share/xdg-config/opencode/opencode.json`.
-Two providers are enabled out of the box:
-
-- **NRP**: OpenAI-compatible endpoint, default model `qwen3`. Requires `OPENAI_API_KEY`
-  injected at runtime. The `{env:OPENAI_API_KEY}` syntax means the key is never stored in
-  the image.
-- **GitHub Copilot**: Built-in provider. Users authenticate once via `/connect` in opencode
-  (device flow at `github.com/login/device`). The token is stored in
-  `~/.local/share/opencode/auth.json` (HOME persistent volume) and survives container
-  restarts. Alternatively, inject `GITHUB_TOKEN` via JupyterHub to skip interactive auth.
+Installed as both a CLI (`/usr/local/bin/opencode`) and a VS Code extension, with no
+provider configured — see [AI assistant configuration](#ai-assistant-configuration).
+Users run `opencode auth login` (or `/connect` in the TUI) and pick a provider; the
+credentials land in `~/.local/share/opencode/auth.json` and the config in
+`~/.config/opencode/opencode.json`, both on the persistent HOME volume, so both
+survive a restart. GitHub Copilot works this way for anyone with a subscription
+(device flow at `github.com/login/device`).
 
 ## Posit Assistant Configuration
 
@@ -156,62 +146,79 @@ the backend inherits it too. (RStudio's own source cites `~/.Renviron` as how pr
 reach that backend.) This is the same reason `set_renviron.sh` exists in this repo.
 
 `install_posit_assistant.sh` writes a delimited managed block into `$(R RHOME)/etc/Renviron.site`
-with `RSTUDIO_POSIT_AI_PATH` and the provider base URL, and chowns the file to `$NB_USER`.
-The startup hook rewrites that block each start to fill in `OPENAI_COMPATIBLE_API_KEY`, which
-is a runtime secret. Keeping it there rather than in `~/.Renviron` means the key lives on the
-container filesystem and is regenerated every start, instead of persisting in the home volume
-after it is rotated. The hook drops `RSTUDIO_POSIT_AI_PATH` from the block when the user has
-their own copy in `~/.local/share/rstudio/pai/bin`, so an in-IDE update still wins.
+with `RSTUDIO_POSIT_AI_PATH`, and chowns the file to `$NB_USER`. The startup hook rewrites that
+block each start, which keeps it idempotent. The hook drops `RSTUDIO_POSIT_AI_PATH` from the
+block when the user has their own copy in `~/.local/share/rstudio/pai/bin`, so an in-IDE update
+still wins.
 
-The assistant reads `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` for its
-"OpenAI Compatible" provider, and env vars outrank both `~/.posit/ai/providers.json` and
-the settings UI.
+No provider is configured. The assistant would read `OPENAI_COMPATIBLE_BASE_URL` /
+`OPENAI_COMPATIBLE_API_KEY` for its "OpenAI Compatible" provider, and env vars outrank both
+`~/.posit/ai/providers.json` and the settings UI — which is exactly why neither is set:
+setting them would override whatever the user picks in the UI. Users configure a provider
+there instead, and `~/.posit/assistant/settings.json` is HOME-resident so the choice sticks.
 
-Model choice is *not* env-configurable in the shipping build (the documented
+Note model choice is *not* env-configurable in the shipping build (the documented
 `POSIT_ASSISTANT_SETTINGS_DEFAULT` / `_ENFORCED` variables are not in the 1.1.0 bundle —
-only `POSIT_AI_PROVIDERS_DEFAULT` / `_ENFORCED` for `providers.json`). So the hook seeds
-`~/.posit/assistant/settings.json` on first launch, opencode-style: HOME-resident, user
-edits persist, delete and restart to re-seed.
+only `POSIT_AI_PROVIDERS_DEFAULT` / `_ENFORCED` for `providers.json`).
 
 The relevant RStudio prefs (`assistant`, `chat_provider`) already default to `posit`, so no
 `/etc/rstudio/rstudio-prefs.json` entry is needed. `RSTUDIO_DISABLE_POSIT_ASSISTANT` is the
 off switch if one is ever wanted.
 
-## Kilo Code Configuration
+## AI assistant configuration
 
-Kilo Code v7 is an opencode fork. Its `data`, `state` and `cache` directories are
-HOME-resident (`~/.local/share/kilo`, `~/.local/state/kilo`, `~/.cache/kilo`) and so persist
-on the JupyterHub home volume, but its **config** directory is `$XDG_CONFIG_HOME/kilo` — and
-this image points `XDG_CONFIG_HOME` at `/opt/share/xdg-config`, which lives in the image, not
-the volume. Everything Kilo writes there (custom providers and models added from the UI,
-agents, MCP servers, all of `kilo.json`) was therefore discarded on every restart.
+The image pre-installs three assistants -- opencode (CLI + extension), Kilo Code
+(VS Code extension) and Posit Assistant (the RStudio AI pane) -- and configures
+**none** of them. No provider, no model, no endpoint, no API key. Users set up
+whichever they want from the app's own UI, and the image's job is to make that
+choice survive a container restart.
 
-`install_llms.sh` replaces that directory with a symlink:
+This is deliberate: an earlier version pre-seeded the NRP Nautilus endpoint and
+read `OPENAI_API_KEY` from the environment. Deployments now hand users their own
+keys interactively, so nothing here should depend on a hub-provided secret.
 
-    /opt/share/xdg-config/kilo -> /home/jovyan/.config/kilo
+### Why config needed redirecting at all
 
-so the extension reads and writes the persistent HOME without knowing anything about it.
+opencode and Kilo Code both read their global config from `$XDG_CONFIG_HOME/<app>`,
+and this image points `XDG_CONFIG_HOME` at `/opt/share/xdg-config` so that
+image-baked config is not shadowed by the JupyterHub HOME mount. That directory
+lives in the image, so anything the apps *write* there is discarded on restart --
+which is precisely a user's provider, model, agents and MCP servers. Kilo v7 is an
+opencode fork and keeps the whole of `kilo.json` there.
+
+`install_llms.sh` replaces both with symlinks into the persistent HOME:
+
+    /opt/share/xdg-config/opencode -> /home/jovyan/.config/opencode
+    /opt/share/xdg-config/kilo     -> /home/jovyan/.config/kilo
+
+so each app reads and writes `~/.config/<app>` without knowing anything about it.
 `kilo debug paths` still prints the `/opt/share` path; it resolves into HOME.
 
-The sysadmin template lives at `/opt/share/kilo-template/kilo.json` (outside `$HOME`, since a
-build-time write to `$HOME` is shadowed by the volume mount). The Jupyter startup hook
-`/etc/jupyter/jupyter_server_config.py`:
+Everything else was already HOME-resident and needed no work: `opencode auth
+login` writes to `~/.local/share/opencode`, Kilo's `data`/`state`/`cache` dirs are
+`~/.local/share/kilo`, `~/.local/state/kilo` and `~/.cache/kilo`, and Posit
+Assistant's settings are in `~/.posit/assistant/settings.json`.
 
-1. Re-asserts the symlink — repairing a container whose `/opt/share` predates this change,
-   and moving anything already written to the ephemeral location into HOME first
-2. Copies the template to `~/.config/kilo/kilo.json` if that file does not exist
+### The startup hook
 
-The template uses the same `{env:OPENAI_API_KEY}` syntax as the opencode config (Kilo reads
-the opencode config format verbatim, including `opencode.json` as a legacy global filename),
-so the key is expanded at read time and never written to disk. Delete
-`~/.config/kilo/kilo.json` and restart to re-seed from the current template.
+`/etc/jupyter/jupyter_server_config.py` runs when the Jupyter server starts,
+before anyone reaches code-server. `/etc/jupyter/` is in Jupyter's config search
+path and outside `$HOME`, so it survives the volume mount. It does two things:
 
-`/etc/jupyter/` is in Jupyter's config search path and outside `$HOME`, so the hook itself
-survives JupyterHub volume mounts.
+1. Re-asserts both symlinks -- repairing a container whose `/opt/share` predates
+   this change, and moving anything already written to the ephemeral location
+   into HOME first rather than dropping it.
+2. Writes `RSTUDIO_POSIT_AI_PATH` into R's `Renviron.site`, so RStudio finds the
+   baked-in assistant bundle instead of prompting each user to download it.
 
-Note the earlier Roo Cline wiring (`roo-cline.autoImportSettingsPath` into the code-server
-`settings.json`) has been removed: the installed extension is `kilocode.kilo-code`, and the v7
-rewrite contributes only `kilo-code.new.*` settings — it never read the Roo keys.
+`Renviron.site` is the only channel that reaches `rsession`: rserver hands it a
+curated ~27-variable environment and drops everything else, so nothing exported
+by the Jupyter server arrives. The managed block is rewritten rather than
+appended, which keeps it idempotent. It carries the install path and nothing
+else.
+
+A user-installed assistant under `~/.local/share/rstudio/pai/bin` wins over the
+system one, since `RSTUDIO_POSIT_AI_PATH` would otherwise shadow it.
 
 ## Testing a change before merging
 
@@ -224,8 +231,8 @@ lines for hand-testing.
 
 `smoke-test.sh` also runs locally against any tag (`bash smoke-test.sh rocker-ml:local`,
 pairing with `run.sh`). It asserts R/Python/Jupyter/RStudio/quarto/opencode are present and
-that the Jupyter startup hook actually seeds the opencode, Kilo Code and Posit Assistant config
-when executed with an `OPENAI_API_KEY` in the environment. It does **not** cover anything
+that the Jupyter startup hook keeps the assistant config dirs on the persistent HOME,
+ships nothing pre-configured, and needs no API key. It does **not** cover anything
 GPU (no GPU runners) or anything that needs a browser — the IDE panes still need a human.
 
 Fork PRs are skipped: `GITHUB_TOKEN` is read-only for them, so the push would 403. PR tags

--- a/README.md
+++ b/README.md
@@ -106,32 +106,29 @@ Additional utilities and VSCode extensions are installed in `/opt/share` (via `X
 
 ### AI Coding Assistants
 
-[opencode](https://opencode.ai) (CLI + VSCode extension) and [Kilo Code](https://kilocode.ai) (VSCode extension) are pre-installed and pre-configured for the NRP Nautilus LLM endpoint.
+[opencode](https://opencode.ai) (CLI + VSCode extension), [Kilo Code](https://kilocode.ai)
+(VSCode extension) and [Posit Assistant](https://assistant.posit.co) (the AI pane in RStudio)
+are pre-installed.
 
-**opencode** has two providers enabled out of the box:
-- **NRP**: default provider, requires `OPENAI_API_KEY` injected via JupyterHub helm chart
-- **GitHub Copilot**: available to any user with a Copilot subscription — run `/connect` in opencode to authenticate via device flow (one-time per user; token persists in home volume)
+None of them is pre-configured with a provider, model or API key — you set up whichever you
+want from the app's own UI, with your own key. Your configuration is stored in your home
+directory, so it persists across server restarts:
 
-**Kilo Code** is seeded with the same NRP provider at Jupyter server start. Its config lives at
-`~/.config/kilo/kilo.json` — on the persistent home volume, reached through a
-`$XDG_CONFIG_HOME/kilo` symlink — so any model or provider a user adds from the Kilo UI
-survives a restart. Delete that file and restart to go back to the image defaults.
-
-**Posit Assistant** (the AI pane in RStudio) is baked into the image at `/etc/rstudio/pai/bin`,
-so users are not prompted to download it on first use. Its install path and the NRP provider
-config are passed to the RStudio session through a managed block in R's `Renviron.site` — the
-only channel that reaches `rsession`, which gets a curated environment from `rserver` rather
-than the container's. It is pointed at NRP via
-`OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` (derived from `OPENAI_API_KEY`)
-in the same startup hook, and the model is seeded into `~/.posit/assistant/settings.json`
-on first launch — edit that file, or use the assistant's own settings UI, to change models
-or switch to another provider (Posit AI, Anthropic, OpenAI, ...).
-
-The only env var required for NRP access:
-
-| Variable | Description |
+| Assistant | Where your configuration is kept |
 |---|---|
-| `OPENAI_API_KEY` | NRP API key |
+| opencode | `~/.config/opencode/opencode.json`, credentials in `~/.local/share/opencode/` |
+| Kilo Code | `~/.config/kilo/kilo.json` |
+| Posit Assistant | `~/.posit/assistant/settings.json` |
+
+For opencode, `opencode auth login` walks through provider setup. GitHub Copilot works for
+anyone with a subscription, via a one-time device-flow login.
+
+Posit Assistant is baked into the image at `/etc/rstudio/pai/bin`, so RStudio does not prompt
+you to download it on first use. Its install path reaches the RStudio session through a managed
+block in R's `Renviron.site` — the only channel that gets there, since `rserver` hands
+`rsession` a curated environment rather than the container's.
+
+No environment variables are required.
 
 ### Testing changes
 

--- a/install_llms.sh
+++ b/install_llms.sh
@@ -10,132 +10,57 @@ curl -fsSL https://opencode.ai/install | bash && \
   mv "${HOME}/.opencode/bin/opencode" /usr/local/bin/opencode && \
   rm -rf "${HOME}/.opencode"
 
-# opencode config — the image-baked file at $XDG_CONFIG_HOME/opencode/opencode.json
-# serves as the sysadmin template. The Jupyter server startup hook below seeds a
-# per-user copy at $HOME/.config/opencode/opencode.json on first launch, and
-# /etc/profile.d/opencode.sh points OPENCODE_CONFIG at that HOME path so user edits
-# persist across container restarts. Delete the user copy and restart to re-seed.
-# Uses {env:VAR_NAME} syntax so the API key is never baked into the image.
-mkdir -p ${XDG_CONFIG_HOME}/opencode
-cat > ${XDG_CONFIG_HOME}/opencode/opencode.json <<'EOF'
-{
-  "model": "nrp/qwen3",
-  "provider": {
-    "nrp": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "NRP",
-      "options": {
-        "baseURL": "https://ellm.nrp-nautilus.io/v1",
-        "apiKey": "{env:OPENAI_API_KEY}"
-      },
-      "models": {
-        "qwen3": {
-          "name": "Qwen3"
-        },
-        "minimax-m2": {
-          "name": "MiniMax M2"
-        }
-      }
-    },
-    "copilot": {}
-  }
-}
-EOF
-chown -R ${NB_USER:-jovyan}:users ${XDG_CONFIG_HOME}/opencode
-
-# Redirect opencode to a HOME-resident config file so user edits persist across
-# container restarts (the JupyterHub HOME volume is persistent; XDG_CONFIG_HOME is not).
-# Set in /etc/profile.d so it applies per-user with ${HOME} expansion at shell init,
-# and is picked up by interactive shells, jupyter-server-spawned terminals, and
-# code-server child processes inheriting the jupyter server env.
-cat > /etc/profile.d/opencode.sh <<'EOF'
-# Per-user opencode config (seeded from /opt/share/xdg-config/opencode/opencode.json
-# by the Jupyter server startup hook on first launch). Delete the file and restart
-# the container to re-seed from the current sysadmin template.
-export OPENCODE_CONFIG="${HOME}/.config/opencode/opencode.json"
-EOF
-chmod 0644 /etc/profile.d/opencode.sh
-
-# Kilo Code (VS Code extension) config persistence.
+# Config persistence for the AI assistants.
 #
-# Kilo v7 is an opencode fork: its data/, state/ and cache/ dirs are HOME-resident
-# (~/.local/share/kilo, ~/.local/state/kilo, ~/.cache/kilo -- all persistent on
-# JupyterHub), but its *config* dir is $XDG_CONFIG_HOME/kilo, and this image points
-# XDG_CONFIG_HOME at /opt/share/xdg-config, which is image-resident and therefore
-# thrown away on every restart. Anything a user configures in the Kilo UI that lands
-# in kilo.json -- custom providers, custom models, agents, MCP servers -- was lost.
+# Neither opencode nor Kilo Code is pre-configured with a provider, a model or a
+# key: users pick their own from each app's own UI. The job here is only to make
+# sure that choice is still there after a restart.
 #
-# Fix: replace $XDG_CONFIG_HOME/kilo with a symlink into the persistent HOME, so the
-# extension reads and writes ~/.config/kilo without knowing anything about it. The
-# sysadmin template stays outside HOME (a build-time write to $HOME is shadowed by
-# the JupyterHub volume mount) and is copied in on first launch by the startup hook.
-mkdir -p /opt/share/kilo-template
-cat > /opt/share/kilo-template/kilo.json <<'EOF'
-{
-  "model": "nrp/qwen3",
-  "provider": {
-    "nrp": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "NRP",
-      "options": {
-        "baseURL": "https://ellm.nrp-nautilus.io/v1",
-        "apiKey": "{env:OPENAI_API_KEY}"
-      },
-      "models": {
-        "qwen3": {
-          "name": "Qwen3"
-        },
-        "minimax-m2": {
-          "name": "MiniMax M2"
-        }
-      }
-    },
-    "copilot": {}
-  }
-}
-EOF
-rm -rf ${XDG_CONFIG_HOME}/kilo
-ln -s /home/${NB_USER:-jovyan}/.config/kilo ${XDG_CONFIG_HOME}/kilo
-chown -h ${NB_USER:-jovyan}:users ${XDG_CONFIG_HOME}/kilo
-chown -R ${NB_USER:-jovyan}:users /opt/share/kilo-template
+# Both read their global config from $XDG_CONFIG_HOME/<app>, and this image
+# points XDG_CONFIG_HOME at /opt/share/xdg-config so that image-baked config is
+# not shadowed by the JupyterHub HOME mount. That directory is image-resident,
+# though, so anything the apps *write* there -- providers, models, agents, MCP
+# servers, and for Kilo the whole of kilo.json -- is discarded when the container
+# restarts. Symlink both into the persistent HOME so they are not.
+#
+# Credentials are already safe: `opencode auth login` writes to
+# ~/.local/share/opencode, and Kilo's data/state/cache dirs are HOME-resident
+# too. Only config needed redirecting.
+for app in opencode kilo; do
+    rm -rf "${XDG_CONFIG_HOME}/${app}"
+    ln -s "/home/${NB_USER:-jovyan}/.config/${app}" "${XDG_CONFIG_HOME}/${app}"
+    chown -h ${NB_USER:-jovyan}:users "${XDG_CONFIG_HOME}/${app}"
+done
 
-# Kilo Code (and Posit Assistant) pre-configuration via Jupyter server startup hook.
+# Jupyter server startup hook.
 # /etc/jupyter/ is in Jupyter's config search path (outside $HOME, survives JupyterHub mounts).
 # This script runs when the Jupyter server starts — before users access code-server.
-# It repairs the $XDG_CONFIG_HOME/kilo -> ~/.config/kilo symlink and seeds the user's
-# kilo.json from the image-baked template on first launch. The API key is not written
-# into the file: {env:OPENAI_API_KEY} is resolved by Kilo at read time from the
-# environment the extension host inherits.
+# It re-asserts the config symlinks above and points RStudio at the baked-in
+# Posit Assistant. It configures no provider and reads no API key.
 mkdir -p /etc/jupyter
 cat > /etc/jupyter/jupyter_server_config.py <<'PYEOF'
-"""Jupyter server startup hook: seed per-user opencode, Kilo Code and Posit Assistant settings."""
-import os, json, pathlib, logging, shutil
+"""Jupyter server startup hook: keep per-user AI assistant config on the persistent HOME."""
+import os, pathlib, logging, shutil
 logger = logging.getLogger(__name__)
 
-def _setup_opencode():
-    # Seed the user's opencode config from the image-baked sysadmin template if
-    # missing, then expose OPENCODE_CONFIG in the jupyter server env so code-server
-    # and any child process inherits it (belt-and-suspenders with profile.d).
-    template = pathlib.Path("/opt/share/xdg-config/opencode/opencode.json")
-    user_config = pathlib.Path.home() / ".config/opencode/opencode.json"
-    if not user_config.exists() and template.exists():
-        user_config.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(template, user_config)
-    os.environ.setdefault("OPENCODE_CONFIG", str(user_config))
-
-def _setup_kilo():
-    # Kilo reads its global config from $XDG_CONFIG_HOME/kilo, which this image points
-    # outside $HOME so that image-baked config is not shadowed by the JupyterHub volume
-    # mount -- but that also means anything Kilo *writes* there (custom providers and
-    # models added from the UI, agents, MCP servers) is discarded on restart. The build
-    # replaces that directory with a symlink to ~/.config/kilo, on the persistent HOME
-    # volume; re-assert it here so a container whose /opt/share predates this change, or
-    # in which something recreated a real directory, still ends up persistent.
+def _persist_config_dirs():
+    # opencode and Kilo Code both keep their global config under
+    # $XDG_CONFIG_HOME/<app>, which this image points outside $HOME so that
+    # image-baked config is not shadowed by the JupyterHub volume mount -- with
+    # the side effect that anything the apps write there is thrown away on
+    # restart. The build replaces both with symlinks into ~/.config; re-assert
+    # them here so a container whose /opt/share predates that change, or in
+    # which something recreated a real directory, still ends up persistent.
+    #
+    # Nothing is seeded into either: no provider, no model, no key. Users
+    # configure the assistants interactively and this is what makes it stick.
     xdg = pathlib.Path(os.environ.get("XDG_CONFIG_HOME", str(pathlib.Path.home() / ".config")))
-    link = xdg / "kilo"
-    target = pathlib.Path.home() / ".config/kilo"
-    target.mkdir(parents=True, exist_ok=True)
-    if link.resolve() != target.resolve():
+    for app in ("opencode", "kilo"):
+        link = xdg / app
+        target = pathlib.Path.home() / ".config" / app
+        target.mkdir(parents=True, exist_ok=True)
+        if link.resolve() == target.resolve():
+            continue
         if link.is_symlink():
             link.unlink()
         elif link.is_dir():
@@ -148,32 +73,24 @@ def _setup_kilo():
         link.parent.mkdir(parents=True, exist_ok=True)
         link.symlink_to(target)
 
-    # Seed the NRP provider on first launch. The template uses {env:OPENAI_API_KEY},
-    # which Kilo expands at read time, so no secret is written to disk. Later edits
-    # from the Kilo UI land in this same file and now survive a restart; delete it and
-    # restart to go back to the template.
-    template = pathlib.Path("/opt/share/kilo-template/kilo.json")
-    user_config = target / "kilo.json"
-    if not user_config.exists() and template.exists():
-        shutil.copyfile(template, user_config)
-
 def _setup_posit_assistant():
     # Posit Assistant (the AI pane in RStudio) is baked into the image by
     # install_posit_assistant.sh, which also writes a managed block into R's
-    # Renviron.site with the install path and the provider base URL.
+    # Renviron.site with the install path. Point RStudio at it, and nothing else
+    # -- no provider, no base URL, no key. Users choose a provider in the
+    # assistant's own settings UI; ~/.posit/assistant/settings.json is on the
+    # persistent HOME, so that choice survives a restart.
     #
     # Why Renviron.site and not the environment: rserver hands rsession a
     # curated ~27-variable environment and drops everything else, so nothing
     # exported here ever reaches the RStudio session. R reads Renviron.site at
     # startup and putenv()s it into the rsession process, which the assistant's
-    # Node backend inherits. Only the API key is missing from that block,
-    # because it is a runtime secret -- fill it in now.
+    # Node backend inherits.
     #
     # Rewriting the whole block (rather than appending) keeps it idempotent
-    # across restarts and means a rotated key never lingers.
+    # across restarts.
     renviron = pathlib.Path(os.environ.get("R_HOME", "/usr/lib/R")) / "etc/Renviron.site"
     begin, end = "# >>> rocker-ml posit-assistant >>>", "# <<< rocker-ml posit-assistant <<<"
-    api_key = os.environ.get("OPENAI_API_KEY", "")
 
     # An assistant the user updated from inside RStudio lives in the persistent
     # HOME and must win; RSTUDIO_POSIT_AI_PATH would otherwise shadow it.
@@ -185,9 +102,6 @@ def _setup_posit_assistant():
     lines = [begin, "# Managed by install_posit_assistant.sh and the Jupyter startup hook."]
     if use_system:
         lines.append(f"RSTUDIO_POSIT_AI_PATH={system_install}")
-    lines.append("OPENAI_COMPATIBLE_BASE_URL=https://ellm.nrp-nautilus.io/v1")
-    if api_key:
-        lines.append(f"OPENAI_COMPATIBLE_API_KEY={api_key}")
     lines.append(end)
 
     try:
@@ -199,36 +113,11 @@ def _setup_posit_assistant():
         existing = head + rest.split(end, 1)[1]
     renviron.write_text(existing.rstrip("\n") + "\n\n" + "\n".join(lines) + "\n")
 
-    # Also export into this process, so terminals and any non-rsession consumer
-    # (the `pa` CLI, code-server terminals) see the same provider config.
-    os.environ.setdefault("OPENAI_COMPATIBLE_BASE_URL", "https://ellm.nrp-nautilus.io/v1")
-    if api_key:
-        os.environ.setdefault("OPENAI_COMPATIBLE_API_KEY", api_key)
-
-    # Model choice is not env-configurable in the shipping assistant build, so
-    # seed the user's settings file on first launch (same pattern as opencode).
-    # It lives in the persistent HOME, so later edits in the UI stick; delete it
-    # and restart the container to go back to the defaults below.
-    settings_file = pathlib.Path.home() / ".posit/assistant/settings.json"
-    if not settings_file.exists():
-        settings_file.parent.mkdir(parents=True, exist_ok=True)
-        settings_file.write_text(json.dumps({
-            "model": {
-                "provider": "openai-compatible",
-                "id": "qwen3"
-            }
-        }, indent=2))
-
 
 try:
-    _setup_opencode()
+    _persist_config_dirs()
 except Exception as e:
-    logger.error(f"opencode setup failed: {e}")
-
-try:
-    _setup_kilo()
-except Exception as e:
-    logger.error(f"Kilo Code setup failed: {e}")
+    logger.error(f"AI assistant config persistence failed: {e}")
 
 try:
     _setup_posit_assistant()

--- a/install_posit_assistant.sh
+++ b/install_posit_assistant.sh
@@ -62,8 +62,8 @@ chmod -R a+rX "$INSTALL_DIR"
 # rserver does NOT pass its own environment to rsession: it builds a curated
 # ~27-variable environment (RS_*/RSTUDIO_*/R_* plus HOME/PATH/USER/LANG/SHELL/
 # LD_LIBRARY_PATH/XDG_CONFIG_HOME) and drops everything else, so anything
-# exported by the Jupyter server -- including RSTUDIO_POSIT_AI_PATH and the
-# provider credentials -- never arrives. /etc/rstudio/env-vars does not help
+# exported by the Jupyter server -- including RSTUDIO_POSIT_AI_PATH -- never
+# arrives. /etc/rstudio/env-vars does not help
 # either; rserver only setenv()s that into its own process.
 #
 # R's Renviron.site is the way through: R putenv()s it into the rsession
@@ -73,10 +73,12 @@ chmod -R a+rX "$INSTALL_DIR"
 # reach it). This is the same reason set_renviron.sh exists in this repo.
 #
 # The file is chowned to the container user so the Jupyter startup hook can
-# refresh the block with the runtime API key, which must not be baked in.
-# Keeping it here rather than in ~/.Renviron means the key lives on the
-# container filesystem and is regenerated every start, instead of persisting
-# in the JupyterHub home volume after it is rotated.
+# rewrite the block on each start.
+#
+# The block carries the install path and nothing else. No provider, base URL or
+# key is baked in: users choose a provider in the assistant's own settings UI,
+# and ~/.posit/assistant/settings.json is on the persistent HOME so the choice
+# survives a restart.
 RENVIRON_SITE="$(R RHOME)/etc/Renviron.site"
 touch "$RENVIRON_SITE"
 cat >> "$RENVIRON_SITE" <<EOF
@@ -84,7 +86,6 @@ cat >> "$RENVIRON_SITE" <<EOF
 # >>> rocker-ml posit-assistant >>>
 # Managed by install_posit_assistant.sh and the Jupyter startup hook.
 RSTUDIO_POSIT_AI_PATH=${INSTALL_DIR}
-OPENAI_COMPATIBLE_BASE_URL=https://ellm.nrp-nautilus.io/v1
 # <<< rocker-ml posit-assistant <<<
 EOF
 chown "${NB_USER:-jovyan}" "$RENVIRON_SITE"

--- a/run.sh
+++ b/run.sh
@@ -1,19 +1,10 @@
 #!/bin/bash
 # Run rocker-ml locally with JupyterLab on http://localhost:8888
-# Goose is configured to use the NRP provider (minimax-m2).
+#
+# The image ships with no AI provider configured -- opencode, Kilo Code and the
+# RStudio assistant are all configured interactively by the user, and their
+# config persists in $HOME. Nothing here needs an API key.
 
 set -euo pipefail
 
-# Pull OPENAI_API_KEY from ~/.bashrc without requiring an interactive shell
-OPENAI_API_KEY=$(grep -oP '(?<=OPENAI_API_KEY=)\S+' ~/.bashrc | head -1)
-
-if [[ -z "$OPENAI_API_KEY" ]]; then
-  echo "ERROR: OPENAI_API_KEY not found in ~/.bashrc" >&2
-  exit 1
-fi
-
-docker run --rm -p 8888:8888 \
-  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
-  -e GOOSE_PROVIDER="nrp" \
-  -e GOOSE_MODEL="minimax-m2" \
-  rocker-ml:local
+docker run --rm -p 8888:8888 rocker-ml:local

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -15,7 +15,7 @@ fail=0
 # One-liner check: runs in a login shell inside the image.
 check() {
     local name="$1"; shift
-    if docker run --rm --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" \
+    if docker run --rm --user jovyan "$IMAGE" \
             bash -lc "$*" >/tmp/smoke.out 2>&1; then
         echo "ok    ${name}"
     else
@@ -28,7 +28,7 @@ check() {
 # Script check: reads the script from stdin, so it can contain any quoting.
 check_script() {
     local name="$1"
-    if docker run --rm -i --user jovyan -e OPENAI_API_KEY=smoke-test-key "$IMAGE" \
+    if docker run --rm -i --user jovyan "$IMAGE" \
             bash -s >/tmp/smoke.out 2>&1; then
         echo "ok    ${name}"
     else
@@ -57,10 +57,10 @@ check "posit assistant readable by user" "head -c1 /etc/rstudio/pai/bin/dist/ser
 # The bundle being on disk is not enough, and neither is exporting variables
 # from the Jupyter server: rserver hands rsession a curated ~27-variable
 # environment and drops everything else. R's Renviron.site is what actually
-# gets through. Run the startup hook, then read the variables back from an R
-# process started with a DELIBERATELY EMPTY environment -- if they show up
-# there, they came from Renviron.site, which is exactly how rsession and the
-# assistant's Node backend will get them.
+# gets through. Run the startup hook, then read the variable back from an R
+# process started with a DELIBERATELY EMPTY environment -- if it shows up
+# there, it came from Renviron.site, which is exactly how rsession and the
+# assistant's Node backend will get it.
 check_script "assistant config reaches an rsession-like environment" <<'SCRIPT'
 set -e
 python3 -c 'import runpy; runpy.run_path("/etc/jupyter/jupyter_server_config.py")'
@@ -69,12 +69,12 @@ python3 -c 'import runpy; runpy.run_path("/etc/jupyter/jupyter_server_config.py"
 # temp RSTUDIO_CONFIG_DIR the rsession-proxy sets (which breaks the /etc lookup).
 env -i HOME="$HOME" PATH=/usr/local/bin:/usr/bin:/bin LANG=C \
     RSTUDIO_CONFIG_DIR="$(mktemp -d)" \
-    R -q -s -e 'cat(Sys.getenv("RSTUDIO_POSIT_AI_PATH"), Sys.getenv("OPENAI_COMPATIBLE_API_KEY"), Sys.getenv("OPENAI_COMPATIBLE_BASE_URL"), Sys.getenv("RSTUDIO_CONFIG_DIR"), sep="\n")' \
+    R -q -s -e 'cat(Sys.getenv("RSTUDIO_POSIT_AI_PATH"), Sys.getenv("RSTUDIO_CONFIG_DIR"), sep="\n")' \
     > /tmp/rsession-env
 
 python3 - <<'PY'
 import pathlib
-path, key, url, cfgdir = pathlib.Path('/tmp/rsession-env').read_text().splitlines()
+path, cfgdir = pathlib.Path('/tmp/rsession-env').read_text().splitlines()
 
 def valid(p):
     p = pathlib.Path(p)
@@ -89,47 +89,64 @@ candidates = [c for c in (
 
 found = next((c for c in candidates if valid(c)), None)
 assert found, f'RStudio would find no assistant install; searched {candidates}'
-assert key == 'smoke-test-key', f'provider API key did not reach the session: {key!r}'
-assert url.startswith('https://'), f'provider base URL did not reach the session: {url!r}'
-print(f'resolves to {found}, credentials present')
+print(f'resolves to {found}')
 PY
 SCRIPT
 
-# The hook is also responsible for the per-user config files.
-check_script "startup hook seeds per-user AI config" <<'SCRIPT'
+# The hook is responsible for keeping assistant config on the persistent HOME.
+check_script "assistant config dirs live on the persistent HOME" <<'SCRIPT'
 set -e
 python3 - <<'PY'
-import json, pathlib, runpy
+import os, pathlib, runpy
 runpy.run_path('/etc/jupyter/jupyter_server_config.py')
 home = pathlib.Path.home()
-assert (home / '.config/opencode/opencode.json').exists(), 'opencode config not seeded'
-s = json.loads((home / '.posit/assistant/settings.json').read_text())
-assert s['model']['provider'] == 'openai-compatible', s
-
-# Kilo's config dir must resolve into the persistent HOME, not $XDG_CONFIG_HOME,
-# or every custom model a user adds is lost on restart.
-import os
-link = pathlib.Path(os.environ.get('XDG_CONFIG_HOME', str(home / '.config'))) / 'kilo'
-target = home / '.config/kilo'
-assert link.resolve() == target.resolve(), f'{link} -> {link.resolve()}, expected {target}'
-k = json.loads((target / 'kilo.json').read_text())
-assert 'nrp' in k['provider'], k
+xdg = pathlib.Path(os.environ.get('XDG_CONFIG_HOME', str(home / '.config')))
+for app in ('opencode', 'kilo'):
+    link, target = xdg / app, home / '.config' / app
+    assert link.resolve() == target.resolve(), f'{link} -> {link.resolve()}, expected {target}'
 PY
 SCRIPT
 
-# A user-added model must survive the hook re-running on the next container start.
-check_script "kilo config survives a restart" <<'SCRIPT'
+# Nothing may be pre-configured: no provider, no model, no API key. Users
+# configure the assistants interactively, and the image must not need a key.
+check_script "assistants ship unconfigured" <<'SCRIPT'
+set -e
+python3 - <<'PY'
+import pathlib
+home = pathlib.Path.home()
+for f in ('.config/opencode/opencode.json', '.config/opencode/opencode.jsonc',
+          '.config/kilo/kilo.json', '.config/kilo/kilo.jsonc',
+          '.posit/assistant/settings.json'):
+    assert not (home / f).exists(), f'{f} was pre-seeded'
+renviron = pathlib.Path('/usr/lib/R/etc/Renviron.site').read_text()
+for var in ('OPENAI_COMPATIBLE_BASE_URL', 'OPENAI_COMPATIBLE_API_KEY', 'OPENAI_API_KEY'):
+    assert var not in renviron, f'{var} is baked into Renviron.site'
+PY
+grep -rq "ellm.nrp-nautilus.io" /etc/jupyter /opt/share/xdg-config /etc/profile.d 2>/dev/null \
+    && { echo "NRP endpoint still baked into the image"; exit 1; }
+test ! -e /etc/profile.d/opencode.sh || { echo "stale opencode profile.d remains"; exit 1; }
+SCRIPT
+
+# A config a user writes must survive the hook re-running on the next start.
+check_script "user config survives a restart" <<'SCRIPT'
 set -e
 python3 - <<'PY'
 import json, pathlib, runpy
 runpy.run_path('/etc/jupyter/jupyter_server_config.py')
-cfg = pathlib.Path.home() / '.config/kilo/kilo.json'
-data = json.loads(cfg.read_text())
-data['provider']['nrp']['models']['smoke-test-model'] = {'name': 'Smoke Test'}
-cfg.write_text(json.dumps(data, indent=2))
+written = {}
+for app, name in (('opencode', 'opencode.json'), ('kilo', 'kilo.json')):
+    # Write through the XDG path, which is what the apps themselves use.
+    import os
+    xdg = pathlib.Path(os.environ.get('XDG_CONFIG_HOME', str(pathlib.Path.home() / '.config')))
+    cfg = xdg / app / name
+    cfg.write_text(json.dumps({'model': f'my-provider/{app}-model'}, indent=2))
+    written[app] = cfg
 runpy.run_path('/etc/jupyter/jupyter_server_config.py')
-data = json.loads(cfg.read_text())
-assert 'smoke-test-model' in data['provider']['nrp']['models'], 'user edit was clobbered'
+for app, cfg in written.items():
+    data = json.loads(cfg.read_text())
+    assert data['model'] == f'my-provider/{app}-model', f'{app} config was clobbered: {data}'
+    # And it is really on the home volume, not the image.
+    assert str(cfg.resolve()).startswith(str(pathlib.Path.home())), cfg.resolve()
 PY
 SCRIPT
 


### PR DESCRIPTION
## Why

The image pre-configured the NRP Nautilus endpoint for opencode, Kilo Code and Posit Assistant, taking the key from `OPENAI_API_KEY` in the environment. Deployments now give users their own keys interactively, so the image should not assume a hub-provided secret.

For Posit Assistant the pre-seeding was worse than redundant: `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` **outrank** both `providers.json` and the settings UI, so a user who picked a provider in the UI would have been silently overridden by the image.

## What changes

No provider, model, endpoint or key is configured for any of the three assistants, and nothing in the image reads `OPENAI_API_KEY`. Users set up whichever they want from the app's own UI.

What stays is the persistence that makes that stick. opencode now gets the same treatment Kilo got in #59:

```
/opt/share/xdg-config/opencode -> /home/jovyan/.config/opencode
/opt/share/xdg-config/kilo     -> /home/jovyan/.config/kilo
```

That replaces the template + `OPENCODE_CONFIG` + `/etc/profile.d/opencode.sh` indirection, which existed only to serve the seeded config. Credentials were already safe — `opencode auth login` writes to `~/.local/share/opencode`.

`run.sh` no longer scrapes a key out of `~/.bashrc` and refuses to start without one.

## Verification

`smoke-test.sh` now passes **no** `OPENAI_API_KEY` to any container, so the image is tested the way it is deployed. Two new checks:

- **assistants ship unconfigured** — no seeded config file for any of the three, no `ellm.nrp-nautilus.io` anywhere under `/etc/jupyter`, `/opt/share/xdg-config` or `/etc/profile.d`, no `OPENAI_*` in `Renviron.site`, no stale `profile.d` drop-in.
- **user config survives a restart** — writes a config through the XDG path each app actually uses, re-runs the hook, and asserts it is intact and resolves under `$HOME`.

Full smoke test passes on a local CPU build (14 checks). Beyond that, an end-to-end test against a real persistent HOME volume: configured a made-up provider in one container, then in a fresh container `opencode models` lists `myprov/mymodel` — so opencode genuinely reads the persisted config, not just the file surviving on disk. Confirmed the seeded dirs are empty and `Renviron.site` carries only `RSTUDIO_POSIT_AI_PATH`.

Docs updated in `README.md` and `AGENTS.md`.

## Downstream

berkeley-dsep-infra/datahub#8471 pins `ml-spatial` by digest and will need re-pinning to the image this produces; I'll update it once this publishes.